### PR TITLE
Patch scipp classes on import

### DIFF
--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -17,8 +17,8 @@ from .wrappers import plot
 
 def patch_scipp():
     """
-    Running this replaces the legacy `plot` function from Scipp with the plopp `plot`
-    wrapper. This patches both the Variable, DataArray, Dataset class methods, as well
+    Running this replaces the `plot` function from Scipp with the plopp `plot`
+    wrapper. This patches both the Variable, DataArray, Dataset classes, as well
     as the main `plot` function in the Scipp module.
     """
     import scipp as sc

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -17,9 +17,9 @@ from .wrappers import plot
 
 def patch_scipp():
     """
-    Running this replaces the `plot` function from Scipp with the plopp `plot`
-    wrapper. This patches both the Variable, DataArray, Dataset classes, as well
-    as the main `plot` function in the Scipp module.
+    Running this replaces the `plot` function from Scipp with the plopp `plot` wrapper.
+    This patches the Variable, DataArray, Dataset classes, as well as the main `plot`
+    function in the Scipp module.
     """
     import scipp as sc
     setattr(sc.Variable, 'plot', plot)

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -13,3 +13,9 @@ from .model import Node, node, input_node
 from .figure import Figure
 from . import widgets
 from .wrappers import plot
+
+from scipp import Variable, DataArray, Dataset
+
+setattr(Variable, 'plot', plot)
+setattr(DataArray, 'plot', plot)
+setattr(Dataset, 'plot', plot)

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -14,8 +14,15 @@ from .figure import Figure
 from . import widgets
 from .wrappers import plot
 
-from scipp import Variable, DataArray, Dataset
 
-setattr(Variable, 'plot', plot)
-setattr(DataArray, 'plot', plot)
-setattr(Dataset, 'plot', plot)
+def patch_scipp():
+    """
+    Running this replaces the legacy `plot` function from Scipp with the plopp `plot`
+    wrapper. This patches both the Variable, DataArray, Dataset class methods, as well
+    as the main `plot` function in the Scipp module.
+    """
+    import scipp as sc
+    setattr(sc.Variable, 'plot', plot)
+    setattr(sc.DataArray, 'plot', plot)
+    setattr(sc.Dataset, 'plot', plot)
+    setattr(sc, 'plot', plot)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def select_plotting_backend():
+def reset_mpl_defaults():
     matplotlib.rcdefaults()
     matplotlib.use('Agg')
 


### PR DESCRIPTION
This enables to use `da.plot()` after having imported `plopp`.