### PR TITLE
Add cache mechanism to graph nodes

### DIFF
--- a/src/plopp/core/graph.py
+++ b/src/plopp/core/graph.py
@@ -18,7 +18,7 @@ def _make_graphviz_digraph(*args, **kwargs):
 def _add_graph_edges(dot, node, inventory, hide_views):
     name = node.id
     inventory.append(name)
-    dot.node(name, label=escape(str(node.func)))
+    dot.node(name, label=escape(str(node.func)) + '\nid = ' + name)
     for child in node.children:
         key = child.id
         if key not in inventory:

--- a/src/plopp/core/model.py
+++ b/src/plopp/core/model.py
@@ -19,6 +19,8 @@ class Node:
         self.kwparents = dict(kwparents)
         for parent in chain(self.parents, self.kwparents.values()):
             parent.add_child(self)
+        self._data = None
+        self._needs_update = True
 
     def remove(self):
         if self.children:
@@ -33,9 +35,15 @@ class Node:
         self.kwparents.clear()
 
     def request_data(self):
-        args = (parent.request_data() for parent in self.parents)
-        kwargs = {key: parent.request_data() for key, parent in self.kwparents.items()}
-        return self.func(*args, **kwargs)
+        if self._needs_update:
+            args = (parent.request_data() for parent in self.parents)
+            kwargs = {
+                key: parent.request_data()
+                for key, parent in self.kwparents.items()
+            }
+            self._data = self.func(*args, **kwargs)
+            self._needs_update = False
+        return self._data
 
     def add_child(self, child):
         self.children.append(child)
@@ -44,6 +52,7 @@ class Node:
         self.views.append(view)
 
     def notify_children(self, message):
+        self._needs_update = True
         self.notify_views(message)
         for child in self.children:
             child.notify_children(message)

--- a/src/plopp/core/model.py
+++ b/src/plopp/core/model.py
@@ -20,7 +20,6 @@ class Node:
         for parent in chain(self.parents, self.kwparents.values()):
             parent.add_child(self)
         self._data = None
-        self._needs_update = True
 
     def remove(self):
         if self.children:
@@ -35,14 +34,13 @@ class Node:
         self.kwparents.clear()
 
     def request_data(self):
-        if self._needs_update:
+        if self._data is None:
             args = (parent.request_data() for parent in self.parents)
             kwargs = {
                 key: parent.request_data()
                 for key, parent in self.kwparents.items()
             }
             self._data = self.func(*args, **kwargs)
-            self._needs_update = False
         return self._data
 
     def add_child(self, child):
@@ -52,7 +50,7 @@ class Node:
         self.views.append(view)
 
     def notify_children(self, message):
-        self._needs_update = True
+        self._data = None
         self.notify_views(message)
         for child in self.children:
             child.notify_children(message)

--- a/tests/core/model_test.py
+++ b/tests/core/model_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
 from plopp import Node, node, View
+from functools import partial
 import pytest
 
 
@@ -94,6 +95,34 @@ def test_two_children_request_data():
     assert av.data == 5
     assert bv.data == 3
     assert cv.data == 7
+
+
+def test_data_request_is_cached():
+    global log
+    log = ''
+
+    def log_and_call(n, f, x=None):
+        global log
+        log += n
+        if x is None:
+            return f()
+        else:
+            return f(x)
+
+    a = Node(partial(log_and_call, n='a', f=lambda: 5))
+    b = node(partial(log_and_call, n='b', f=lambda x: x - 2))(x=a)
+    c = node(partial(log_and_call, n='c', f=lambda x: x + 2))(x=a)
+    d = node(partial(log_and_call, n='d', f=lambda x: x**2))(x=c)
+    av = DataView(a)
+    bv = DataView(b)
+    cv = DataView(c)
+    dv = DataView(d)
+
+    a.notify_children(message='hello from a')
+    assert log == 'abcd'  # 'a' should only appear once in the log
+    log = ''
+    c.notify_children(message='hello from c')
+    assert log == 'cd'  # 'c' requests data from 'a' but 'a' is cached so no 'a' in log
 
 
 def test_remove_node():

--- a/tests/core/model_test.py
+++ b/tests/core/model_test.py
@@ -113,10 +113,10 @@ def test_data_request_is_cached():
     b = node(partial(log_and_call, n='b', f=lambda x: x - 2))(x=a)
     c = node(partial(log_and_call, n='c', f=lambda x: x + 2))(x=a)
     d = node(partial(log_and_call, n='d', f=lambda x: x**2))(x=c)
-    av = DataView(a)
-    bv = DataView(b)
-    cv = DataView(c)
-    dv = DataView(d)
+    av = DataView(a)  # noqa: F841
+    bv = DataView(b)  # noqa: F841
+    cv = DataView(c)  # noqa: F841
+    dv = DataView(d)  # noqa: F841
 
     a.notify_children(message='hello from a')
     assert log == 'abcd'  # 'a' should only appear once in the log


### PR DESCRIPTION
Fixes #27 

Small benchmark:
```Py
import plopp as pp
from plopp.widgets import SliceWidget, slice_dims, Box
from plopp import figure, input_node, widget_node, node, Node, View
import scipp as sc

N = 10000
M = 10000
xx = sc.arange('x', float(N))
yy = sc.arange('y', float(M))
da = sc.DataArray(data=xx, coords={'x': xx})
db = sc.DataArray(data=yy, coords={'y': yy})


class DataView(View):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.data = None

    def notify_view(self, message):
        node_id = message["node_id"]
        self.data = self.graph_nodes[node_id].request_data()


a = input_node(da)
b = input_node(db)

c = node(lambda x, y: x * y)(x=a, y=b)

nodes = []
views = []
for i in range(20):
    nodes.append(node(lambda x: x[x.dims[-1], 0])(x=c))

for j in range(2):
    for n in list(nodes):
        for i in range(2):
            nd = node(lambda x: x * (i + j))(x=n)
            nodes.append(nd)
            views.append(DataView(nd))

print(views[-1].data)

a.notify_children(message='hello from a')

print(views[-1].data)
```

**Before:**
real	0m17.526s
user	0m28.001s

**After:**
real	0m1.117s
user	0m1.638s

I saw no difference in RAM usage, but maybe we can think of an example where more RAM would be used?
In all the ones I tried, references to large data were being kept by either the views/figures, or the children nodes themselves.