### PR TITLE
Add support for string coords

### DIFF
--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -18,7 +18,6 @@ def coord_as_bin_edges(da, key, dim=None):
         x = sc.arange(dim, float(x.shape[0]), unit=x.unit)
     if da.meta.is_edges(key, dim=dim):
         return x
-    # idim = x.dims.index(dim)
     if x.sizes[dim] < 2:
         half = sc.scalar(0.5, unit=x.unit)
         return sc.concat([x[dim, 0:1] - half, x[dim, 0:1] + half], dim)

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -50,7 +50,7 @@ def number_to_variable(x):
     """
     Convert the input int or float to a variable.
     """
-    return scalar(x, unit=None) if isinstance(x, (int, float)) else x
+    return sc.scalar(x, unit=None) if isinstance(x, (int, float)) else x
 
 
 def name_with_unit(var=None, name=None, log=False):

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from scipp import scalar, concat, midpoints
+import scipp as sc
 import uuid
 from functools import reduce
 
@@ -14,19 +14,21 @@ def coord_as_bin_edges(da, key, dim=None):
     if dim is None:
         dim = key
     x = da.meta[key]
+    if x.dtype == str:
+        x = sc.arange(dim, float(x.shape[0]), unit=x.unit)
     if da.meta.is_edges(key, dim=dim):
         return x
-    idim = x.dims.index(dim)
-    if x.shape[idim] < 2:
-        half = scalar(0.5, unit=x.unit)
-        return concat([x[dim, 0:1] - half, x[dim, 0:1] + half], dim)
+    # idim = x.dims.index(dim)
+    if x.sizes[dim] < 2:
+        half = sc.scalar(0.5, unit=x.unit)
+        return sc.concat([x[dim, 0:1] - half, x[dim, 0:1] + half], dim)
     else:
-        center = midpoints(x, dim=dim)
+        center = sc.midpoints(x, dim=dim)
         # Note: use range of 0:1 to keep dimension dim in the slice to avoid
         # switching round dimension order in concatenate step.
         left = center[dim, 0:1] - (x[dim, 1] - x[dim, 0])
         right = center[dim, -1] + (x[dim, -1] - x[dim, -2])
-        return concat([left, center, right], dim)
+        return sc.concat([left, center, right], dim)
 
 
 def repeat(x, dim, n):

--- a/src/plopp/graphics/canvas.py
+++ b/src/plopp/graphics/canvas.py
@@ -6,6 +6,7 @@ from ..core.utils import number_to_variable
 from .utils import fig_to_bytes, silent_mpl_figure
 
 import matplotlib.pyplot as plt
+from matplotlib.collections import QuadMesh
 import numpy as np
 import scipp as sc
 from typing import Any, Tuple
@@ -92,17 +93,18 @@ class Canvas:
             self._ymin = min(self._ymin, ymin)
             self._ymax = max(self._ymax, ymax)
         for c in self.ax.collections:
-            coords = c.get_coordinates()
-            left, right = fix_empty_range(
-                find_limits(sc.array(dims=['x', 'y'], values=coords[..., 0]),
-                            scale=self.xscale))
-            bottom, top = fix_empty_range(
-                find_limits(sc.array(dims=['x', 'y'], values=coords[..., 1]),
-                            scale=self.yscale))
-            self._xmin = min(self._xmin, left.value)
-            self._xmax = max(self._xmax, right.value)
-            self._ymin = min(self._ymin, bottom.value)
-            self._ymax = max(self._ymax, top.value)
+            if isinstance(c, QuadMesh):
+                coords = c.get_coordinates()
+                left, right = fix_empty_range(
+                    find_limits(sc.array(dims=['x', 'y'], values=coords[..., 0]),
+                                scale=self.xscale))
+                bottom, top = fix_empty_range(
+                    find_limits(sc.array(dims=['x', 'y'], values=coords[..., 1]),
+                                scale=self.yscale))
+                self._xmin = min(self._xmin, left.value)
+                self._xmax = max(self._xmax, right.value)
+                self._ymin = min(self._ymin, bottom.value)
+                self._ymax = max(self._ymax, top.value)
         self.ax.set_xlim(_none_if_not_finite(self._xmin),
                          _none_if_not_finite(self._xmax))
         self.ax.set_ylim(_none_if_not_finite(self._ymin),

--- a/src/plopp/graphics/line.py
+++ b/src/plopp/graphics/line.py
@@ -125,9 +125,8 @@ class Line:
             if data["mask"] is not None:
                 data["mask"]["y"] = np.concatenate(
                     (data["mask"]["y"][0:1], data["mask"]["y"]))
-            data["variances"]["x"] = 0.5 * (x[1:] + x[:-1])
-        else:
-            data["variances"]["x"] = x
+        if self._data.variances is not None:
+            data["variances"]["x"] = 0.5 * (x[1:] + x[:-1]) if hist else x
         data["variances"]["y"] = y
         data["hist"] = hist
         return data

--- a/src/plopp/graphics/mesh.py
+++ b/src/plopp/graphics/mesh.py
@@ -23,33 +23,29 @@ def _get_dims_of_1d_and_2d_coords(coords):
     return dim_1d, dim_2d
 
 
-def _maybe_repeat_values(data, coords):
-    dim_1d, dim_2d = _get_dims_of_1d_and_2d_coords(coords)
+def _maybe_repeat_values(data, dim_1d, dim_2d):
     if dim_2d is None:
         return data
     return repeat(data, dim=dim_1d[1], n=2)[dim_1d[1], :-1]
 
 
-def _from_data_array_to_pcolormesh(data, coords):
-    z = _maybe_repeat_values(data=data, coords=coords)
-    dim_1d, dim_2d = _get_dims_of_1d_and_2d_coords(coords)
+def _from_data_array_to_pcolormesh(data, coords, dim_1d, dim_2d):
+    z = _maybe_repeat_values(data=data, dim_1d=dim_1d, dim_2d=dim_2d)
     if dim_2d is None:
-        return coords['x']['var'], coords['y']['var'], z
+        return coords['x'], coords['y'], z
 
     # Broadcast 1d coord to 2d and repeat along 1d dim
     # TODO: It may be more efficient here to first repeat and then broadcast, but
     # the current order is simpler in implementation.
-    broadcasted_coord = repeat(sc.broadcast(coords[dim_1d[0]]['var'],
+    broadcasted_coord = repeat(sc.broadcast(coords[dim_1d[0]],
                                             sizes={
-                                                **coords[dim_2d[0]]['var'].sizes,
-                                                **coords[dim_1d[0]]['var'].sizes
+                                                **coords[dim_2d[0]].sizes,
+                                                **coords[dim_1d[0]].sizes
                                             }).transpose(data.dims),
                                dim=dim_1d[1],
                                n=2)
     # Repeat 2d coord along 1d dim
-    repeated_coord = repeat(coords[dim_2d[0]]['var'].transpose(data.dims),
-                            dim=dim_1d[1],
-                            n=2)
+    repeated_coord = repeat(coords[dim_2d[0]].transpose(data.dims), dim=dim_1d[1], n=2)
     out = {dim_1d[0]: broadcasted_coord[dim_1d[1], 1:-1], dim_2d[0]: repeated_coord}
     return out['x'], out['y'], z
 
@@ -75,13 +71,18 @@ class Mesh:
 
         self._ax = canvas.ax
         self._data = data
-        self._dims = {'x': self._data.dims[1], 'y': self._data.dims[0]}
-        self._bin_edge_coords = {
+        self._dim_1d, self._dim_2d = _get_dims_of_1d_and_2d_coords({
             k: {
-                'dim': self._dims[k],
-                'var': coord_as_bin_edges(self._data, self._dims[k])
+                'dim': self._data.dims[i],
+                'var': self._data.meta[self._data.dims[i]]
             }
-            for k in 'xy'
+            for i, k in enumerate('yx')
+        })
+
+        maybe_bin_edge_coords = {
+            k: coord_as_bin_edges(self._data, self._data.dims[i])
+            if self._dim_2d is not None else self._data.meta[self._data.dims[i]]
+            for i, k in enumerate('yx')
         }
 
         self._xlabel = None
@@ -100,7 +101,9 @@ class Mesh:
             self._extend = 'max'
 
         x, y, z = _from_data_array_to_pcolormesh(data=self._data.data,
-                                                 coords=self._bin_edge_coords)
+                                                 coords=maybe_bin_edge_coords,
+                                                 dim_1d=self._dim_1d,
+                                                 dim_2d=self._dim_2d)
         self._mesh = self._ax.pcolormesh(x.values,
                                          y.values,
                                          z.values,
@@ -111,14 +114,15 @@ class Mesh:
 
     @property
     def data(self):
-        out = sc.DataArray(data=_maybe_repeat_values(data=self._data.data,
-                                                     coords=self._bin_edge_coords))
+        out = sc.DataArray(data=_maybe_repeat_values(
+            data=self._data.data, dim_1d=self._dim_1d, dim_2d=self._dim_2d))
         if self._data.masks:
             out.masks['one_mask'] = _maybe_repeat_values(data=sc.broadcast(
                 merge_masks(self._data.masks),
                 dims=self._data.dims,
                 shape=self._data.shape),
-                                                         coords=self._bin_edge_coords)
+                                                         dim_1d=self._dim_1d,
+                                                         dim_2d=self._dim_2d)
         return out
 
     def set_colors(self, rgba):

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -81,3 +81,11 @@ def test_update_does_not_shrink_limits():
     new_lims = fig.canvas.ax.get_ylim()
     assert new_lims[0] == old_lims[0]
     assert new_lims[1] == old_lims[1]
+
+
+def test_with_string_coord():
+    strings = ['a', 'b', 'c', 'd', 'e']
+    da = sc.DataArray(data=sc.arange('x', 5.),
+                      coords={'x': sc.array(dims=['x'], values=strings, unit='m')})
+    fig = Figure1d(input_node(da))
+    assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -89,3 +89,11 @@ def test_with_string_coord():
                       coords={'x': sc.array(dims=['x'], values=strings, unit='m')})
     fig = Figure1d(input_node(da))
     assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings
+
+
+def test_with_strings_as_bin_edges():
+    strings = ['a', 'b', 'c', 'd', 'e', 'f']
+    da = sc.DataArray(data=sc.arange('x', 5.),
+                      coords={'x': sc.array(dims=['x'], values=strings, unit='m')})
+    fig = Figure1d(input_node(da))
+    assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -38,7 +38,31 @@ def test_create_with_node():
     da = dense_data_array(ndim=1)
     fig = Figure1d(input_node(da))
     assert len(fig.artists) == 1
-    assert sc.identical(list(fig.artists.values())[0]._data, da)
+    line = list(fig.artists.values())[0]
+    assert sc.identical(line._data, da)
+    assert line._error is None
+
+
+def test_with_errorbars():
+    da = dense_data_array(ndim=1, with_variance=True)
+    fig = Figure1d(input_node(da))
+    assert len(fig.artists) == 1
+    line = list(fig.artists.values())[0]
+    assert line._error is not None
+    fig = Figure1d(input_node(da), errorbars=False)
+    line = list(fig.artists.values())[0]
+    assert line._error is None
+
+
+def test_with_binedges():
+    da = dense_data_array(ndim=1, binedges=True)
+    fig = Figure1d(input_node(da))
+    assert len(fig.artists) == 1
+    line = list(fig.artists.values())[0]
+    assert sc.identical(line._data, da)
+    xdata = line._line.get_xdata()
+    assert np.allclose(xdata, da.coords['xx'].values)
+    assert len(xdata) == da.sizes['xx'] + 1
 
 
 def test_log_norm():

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -5,6 +5,7 @@ from plopp.data import dense_data_array
 from plopp.graphics.fig1d import Figure1d
 from plopp.graphics.line import Line
 from plopp import input_node
+import numpy as np
 import scipp as sc
 import pytest
 

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -42,6 +42,21 @@ def test_create_with_node():
     assert sc.identical(list(fig.artists.values())[0]._data, da)
 
 
+def test_create_with_bin_edges():
+    da = dense_data_array(ndim=2, binedges=True)
+    fig = Figure2d(input_node(da))
+    assert len(fig.artists) == 1
+    assert sc.identical(list(fig.artists.values())[0]._data, da)
+
+
+def test_create_with_only_one_bin_edge_coord():
+    da = dense_data_array(ndim=2, binedges=True)
+    da.coords['xx'] = sc.midpoints(da.coords['xx'])
+    fig = Figure2d(input_node(da))
+    assert len(fig.artists) == 1
+    assert sc.identical(list(fig.artists.values())[0]._data, da)
+
+
 def test_log_norm():
     fig = Figure2d(norm='log')
     assert fig.colormapper.norm == 'log'

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -129,3 +129,14 @@ def test_with_strings_as_bin_edges():
                       })
     fig = Figure2d(input_node(da))
     assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings
+
+
+def test_with_strings_as_bin_edges_other_coord_is_bin_centers():
+    strings = ['a', 'b', 'c', 'd', 'e', 'f']
+    da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=np.random.random((5, 5))),
+                      coords={
+                          'x': sc.array(dims=['x'], values=strings, unit='s'),
+                          'y': sc.arange('y', 5., unit='m')
+                      })
+    fig = Figure2d(input_node(da))
+    assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -92,3 +92,25 @@ def test_update_on_one_mesh_changes_colors_on_second_mesh():
     a.func = lambda: da1 * 5.0
     a.notify_children('updated a')
     assert not np.allclose(old_b_colors, f.artists[b.id]._mesh.get_facecolors())
+
+
+def test_with_string_coord():
+    strings = ['a', 'b', 'c', 'd', 'e']
+    da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=np.random.random((5, 5))),
+                      coords={
+                          'x': sc.array(dims=['x'], values=strings, unit='s'),
+                          'y': sc.arange('y', 5., unit='m')
+                      })
+    fig = Figure2d(input_node(da))
+    assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings
+
+
+def test_with_strings_as_bin_edges():
+    strings = ['a', 'b', 'c', 'd', 'e', 'f']
+    da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=np.random.random((5, 5))),
+                      coords={
+                          'x': sc.array(dims=['x'], values=strings, unit='s'),
+                          'y': sc.arange('y', 6., unit='m')
+                      })
+    fig = Figure2d(input_node(da))
+    assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings

--- a/tests/graphics/mesh_test.py
+++ b/tests/graphics/mesh_test.py
@@ -10,7 +10,6 @@ import scipp as sc
 def test_mesh_creation():
     da = dense_data_array(ndim=2)
     mesh = Mesh(canvas=Canvas(), data=da)
-    assert mesh._dims == {'x': 'xx', 'y': 'yy'}
     assert sc.identical(mesh._data, da)
 
 
@@ -29,7 +28,8 @@ def test_mesh_creation_masks():
 def test_mesh_creation_ragged_coord():
     da = dense_data_array(ndim=2, ragged=True)
     mesh = Mesh(canvas=Canvas(), data=da)
-    assert mesh._dims == {'x': 'xx', 'y': 'yy'}
+    assert mesh._dim_2d == ('x', 'xx')
+    assert mesh._dim_1d == ('y', 'yy')
     assert sc.identical(mesh._data, da)
 
 


### PR DESCRIPTION
1D plots were mostly working after #36 , but some fixes were needed for 2d plots.

When string coord is bin centers:
```Py
strings = ['a', 'b', 'c', 'd', 'e']
da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=np.random.random((5, 5))),
                  coords={
                      'x': sc.array(dims=['x'], values=strings, unit='s'),
                      'y': sc.arange('y', 6., unit='m')
                  })
pp.plot(da)
```
![Screenshot at 2022-10-23 20-59-26](https://user-images.githubusercontent.com/39047984/197410593-45b0694b-0104-44de-93b4-a260a325ed43.png)

When string coord is bin edges:
```Py
strings = ['a', 'b', 'c', 'd', 'e', 'f']
da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=np.random.random((5, 5))),
                  coords={
                      'x': sc.array(dims=['x'], values=strings, unit='s'),
                      'y': sc.arange('y', 6., unit='m')
                  })
pp.plot(da)
```
![Screenshot at 2022-10-23 21-00-09](https://user-images.githubusercontent.com/39047984/197410607-158cd260-04e1-4eae-99d5-56fe43129cb3.png)

Fixes #40 