### PR TITLE
Fix kwargs that were not being forwarded to mesh

### DIFF
--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -24,12 +24,14 @@ class Figure2d(BaseFig):
                  grid=False,
                  crop=None,
                  cbar=True,
+                 title=None,
                  **kwargs):
 
         super().__init__(*nodes)
 
         self._scale = {} if scale is None else scale
-        self.canvas = Canvas(cbar=cbar, aspect=aspect, grid=grid)
+        self._kwargs = kwargs
+        self.canvas = Canvas(cbar=cbar, aspect=aspect, grid=grid, title=title)
         self.colormapper = ColorMapper(cmap=cmap,
                                        mask_cmap=mask_cmap,
                                        norm=norm,
@@ -53,7 +55,7 @@ class Figure2d(BaseFig):
 
         if key not in self.artists:
 
-            mesh = Mesh(canvas=self.canvas, data=new_values)
+            mesh = Mesh(canvas=self.canvas, data=new_values, **self._kwargs)
             self.artists[key] = mesh
             self.colormapper[key] = mesh
             self.dims.update({

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -140,3 +140,13 @@ def test_with_strings_as_bin_edges_other_coord_is_bin_centers():
                       })
     fig = Figure2d(input_node(da))
     assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings
+
+
+def test_kwargs_are_forwarded_to_artist():
+    da = dense_data_array(ndim=2)
+    fig = Figure2d(input_node(da), rasterized=True)
+    artist = list(fig.artists.values())[0]
+    assert artist._mesh.get_rasterized()
+    fig = Figure2d(input_node(da), rasterized=False)
+    artist = list(fig.artists.values())[0]
+    assert not artist._mesh.get_rasterized()


### PR DESCRIPTION
With this, you can now do, e.g.
```Py
da = pp.data.dense_data_array(ndim=2)
pp.plot(da, rasterized=False)
```