### PR TITLE
Make figure images not blurry in docs

### DIFF
--- a/src/plopp/graphics/canvas.py
+++ b/src/plopp/graphics/canvas.py
@@ -71,14 +71,7 @@ class Canvas:
 
     def to_image(self):
         from ipywidgets import Image
-        bounds = self.fig.get_tightbbox(self.fig.canvas.get_renderer()).bounds
-        width = bounds[2] - bounds[0]
-        height = bounds[3] - bounds[1]
-        dpi = self.fig.get_dpi()
-        return Image(value=fig_to_bytes(self.fig),
-                     width=width * dpi,
-                     height=height * dpi,
-                     format='png')
+        return Image(value=fig_to_bytes(self.fig), format='png')
 
     def autoscale(self, draw=True):
         """


### PR DESCRIPTION
Left: after, Right: before
![Screenshot at 2022-10-27 10-06-48](https://user-images.githubusercontent.com/39047984/198228332-bcd48879-6d58-4271-b801-72d837a3d987.png)
