### PR TITLE
Smaller default figsize

### DIFF
--- a/src/plopp/functions/plot.py
+++ b/src/plopp/functions/plot.py
@@ -8,7 +8,7 @@ from .common import preprocess
 from scipp import Variable, Dataset
 from scipp.typing import VariableLike
 from numpy import ndarray
-from typing import Union, Dict, Literal
+from typing import Union, Dict, Literal, Tuple
 
 
 def plot(obj: Union[VariableLike, ndarray, Dict[str, Union[VariableLike, ndarray]]],
@@ -24,6 +24,7 @@ def plot(obj: Union[VariableLike, ndarray, Dict[str, Union[VariableLike, ndarray
          title: str = None,
          vmin: Variable = None,
          vmax: Variable = None,
+         figsize: Tuple[float, float] = (6., 4.),
          **kwargs):
     """Plot a Scipp object.
 
@@ -63,6 +64,8 @@ def plot(obj: Union[VariableLike, ndarray, Dict[str, Union[VariableLike, ndarray
     vmax:
         Upper bound for data to be displayed (y-axis for 1d plots, colorscale for
         2d plots).
+    figsize:
+        The width and height of the figure, in inches.
     **kwargs:
         All other kwargs are directly forwarded to Matplotlib, the underlying plotting
         library. The underlying functions called are the following:
@@ -83,7 +86,8 @@ def plot(obj: Union[VariableLike, ndarray, Dict[str, Union[VariableLike, ndarray
         'scale': scale,
         'title': title,
         'vmin': vmin,
-        'vmax': vmax
+        'vmax': vmax,
+        'figsize': figsize
     }
 
     if isinstance(obj, (dict, Dataset)):

--- a/src/plopp/functions/scatter3d.py
+++ b/src/plopp/functions/scatter3d.py
@@ -4,7 +4,7 @@
 from ..core import input_node
 
 import scipp as sc
-from typing import Union, Literal, Tuple
+from typing import Literal, Tuple
 
 
 def scatter3d(da: sc.DataArray,
@@ -13,7 +13,7 @@ def scatter3d(da: sc.DataArray,
               y: str = None,
               z: str = None,
               pos: str = None,
-              figsize: Tuple[Union[int, float]] = None,
+              figsize: Tuple[int, int] = (600, 400),
               norm: Literal['linear', 'log'] = 'linear',
               title: str = None,
               vmin: sc.Variable = None,

--- a/src/plopp/graphics/canvas.py
+++ b/src/plopp/graphics/canvas.py
@@ -53,7 +53,7 @@ class Canvas:
     def __init__(self,
                  ax: plt.Axes = None,
                  cax: plt.Axes = None,
-                 figsize: Tuple[float, float] = None,
+                 figsize: Tuple[float, float] = (6., 4.),
                  title: str = None,
                  grid: bool = False,
                  vmin: sc.Variable = None,

--- a/src/plopp/graphics/canvas3d.py
+++ b/src/plopp/graphics/canvas3d.py
@@ -25,7 +25,7 @@ class Canvas3d:
         The title to be placed above the figure.
     """
 
-    def __init__(self, figsize: Tuple[float, float] = None, title: str = None):
+    def __init__(self, figsize: Tuple[int, int] = (600, 400), title: str = None):
 
         # TODO: the title is still unused.
 
@@ -34,9 +34,6 @@ class Canvas3d:
         self.outline = None
         self.axticks = None
         self.figsize = figsize
-
-        if self.figsize is None:
-            self.figsize = (600, 400)
         width, height = self.figsize
 
         self.camera = p3.PerspectiveCamera(aspect=width / height)

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -65,7 +65,7 @@ class Figure1d(BaseFig):
                  grid: bool = False,
                  crop: Dict[str, Dict[str, sc.Variable]] = None,
                  title: str = None,
-                 figsize: Tuple[float, float] = None,
+                 figsize: Tuple[float, float] = (6., 4.),
                  ax: Any = None,
                  **kwargs):
 

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -72,7 +72,7 @@ class Figure2d(BaseFig):
                  crop: Dict[str, Dict[str, sc.Variable]] = None,
                  cbar: bool = True,
                  title: str = None,
-                 figsize: Tuple[float, float] = None,
+                 figsize: Tuple[float, float] = (6., 4.),
                  ax: Any = None,
                  cax: Any = None,
                  **kwargs):

--- a/src/plopp/graphics/fig3d.py
+++ b/src/plopp/graphics/fig3d.py
@@ -56,7 +56,7 @@ class Figure3d(BaseFig):
                  norm: Literal['linear', 'log'] = 'linear',
                  vmin: sc.Variable = None,
                  vmax: sc.Variable = None,
-                 figsize: Tuple[float, float] = None,
+                 figsize: Tuple[int, int] = (600, 400),
                  title: str = None,
                  **kwargs):
 


### PR DESCRIPTION
After #64 I feel that the figures were a little too large by default.
We reduce a bit the default figure size, and propagate the argument and its default value so that it is properly documented in the reference API pages.