### PR TITLE
Make scipp an optional dependency in conda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -12,10 +12,11 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - python >=3.8
+    - python >= 3.8
     - python-dateutil
-    - scipp
     - matplotlib
+  run_constrained:
+    - scipp >= 0.12
 
 test:
   imports:


### PR DESCRIPTION
Similar to pip except that there seems to be no way to specify 'extras'.

I tried to install plopp with conda in my scipp dev env and it tried to install scipp from conda, too. But using version 0.11! The minimum version specified here matches the one in `setup.cfg`.