### PR TITLE
Switch to PNG repr for static figure when there are too many markers in plot

### DIFF
--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -48,6 +48,10 @@ class Figure1d(BaseFig):
     ax:
         If supplied, use these axes to create the figure. If none are supplied, the
         canvas will create its own axes.
+    form:
+        Format of the figure displayed in the Jupyter notebook. If ``None``, a SVG is
+        created as long as the number of markers in the figure is not too large. If too
+        many markers are drawn, a PNG image is created instead.
     **kwargs:
         All other kwargs are forwarded to Matplotlib:
 
@@ -69,6 +73,7 @@ class Figure1d(BaseFig):
                  title: str = None,
                  figsize: Tuple[float, float] = (6., 4.),
                  ax: Any = None,
+                 form: Literal['svg', 'png'] = None,
                  **kwargs):
 
         super().__init__(*nodes)
@@ -77,6 +82,7 @@ class Figure1d(BaseFig):
         self._errorbars = errorbars
         self._mask_color = mask_color
         self._kwargs = kwargs
+        self._repr_format = form
         self.canvas = Canvas(cbar=False,
                              aspect=aspect,
                              grid=grid,

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -7,7 +7,7 @@ from .canvas import Canvas
 from .line import Line
 
 import scipp as sc
-from typing import Any, Dict, Literal, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 
 class Figure1d(BaseFig):
@@ -48,7 +48,7 @@ class Figure1d(BaseFig):
     ax:
         If supplied, use these axes to create the figure. If none are supplied, the
         canvas will create its own axes.
-    form:
+    format:
         Format of the figure displayed in the Jupyter notebook. If ``None``, a SVG is
         created as long as the number of markers in the figure is not too large. If too
         many markers are drawn, a PNG image is created instead.
@@ -62,18 +62,18 @@ class Figure1d(BaseFig):
     def __init__(self,
                  *nodes,
                  norm: Literal['linear', 'log'] = 'linear',
-                 vmin: Union[sc.Variable, int, float] = None,
-                 vmax: Union[sc.Variable, int, float] = None,
-                 scale: Dict[str, str] = None,
+                 vmin: Optional[Union[sc.Variable, int, float]] = None,
+                 vmax: Optional[Union[sc.Variable, int, float]] = None,
+                 scale: Optional[Dict[str, str]] = None,
                  errorbars: bool = True,
                  mask_color: str = 'black',
                  aspect: Literal['auto', 'equal'] = 'auto',
                  grid: bool = False,
-                 crop: Dict[str, Dict[str, sc.Variable]] = None,
-                 title: str = None,
+                 crop: Optional[Dict[str, Dict[str, sc.Variable]]] = None,
+                 title: Optional[str] = None,
                  figsize: Tuple[float, float] = (6., 4.),
-                 ax: Any = None,
-                 form: Literal['svg', 'png'] = None,
+                 ax: Optional[Any] = None,
+                 format: Optional[Literal['svg', 'png']] = None,
                  **kwargs):
 
         super().__init__(*nodes)
@@ -82,7 +82,7 @@ class Figure1d(BaseFig):
         self._errorbars = errorbars
         self._mask_color = mask_color
         self._kwargs = kwargs
-        self._repr_format = form
+        self._repr_format = format
         self.canvas = Canvas(cbar=False,
                              aspect=aspect,
                              grid=grid,

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -8,7 +8,7 @@ from .colormapper import ColorMapper
 from .mesh import Mesh
 
 import scipp as sc
-from typing import Any, Dict, Literal, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 
 class Figure2d(BaseFig):
@@ -57,7 +57,7 @@ class Figure2d(BaseFig):
     cax:
         If supplied, use these axes for the colorbar. If none are supplied, and a
         colorbar is required, the canvas will create its own axes.
-    form:
+    format:
         Format of the figure displayed in the Jupyter notebook. If ``None``, a SVG is
         created as long as the number of markers in the figure is not too large. If too
         many markers are drawn, a PNG image is created instead.
@@ -70,25 +70,25 @@ class Figure2d(BaseFig):
                  cmap: str = 'viridis',
                  mask_cmap: str = 'gray',
                  norm: Literal['linear', 'log'] = 'linear',
-                 vmin: Union[sc.Variable, int, float] = None,
-                 vmax: Union[sc.Variable, int, float] = None,
-                 scale: Dict[str, str] = None,
+                 vmin: Optional[Union[sc.Variable, int, float]] = None,
+                 vmax: Optional[Union[sc.Variable, int, float]] = None,
+                 scale: Optional[Dict[str, str]] = None,
                  aspect: Literal['auto', 'equal'] = 'auto',
                  grid: bool = False,
-                 crop: Dict[str, Dict[str, sc.Variable]] = None,
+                 crop: Optional[Dict[str, Dict[str, sc.Variable]]] = None,
                  cbar: bool = True,
-                 title: str = None,
+                 title: Optional[str] = None,
                  figsize: Tuple[float, float] = (6., 4.),
-                 ax: Any = None,
-                 cax: Any = None,
-                 form: Literal['svg', 'png'] = None,
+                 ax: Optional[Any] = None,
+                 cax: Optional[Any] = None,
+                 format: Optional[Literal['svg', 'png']] = None,
                  **kwargs):
 
         super().__init__(*nodes)
 
         self._scale = {} if scale is None else scale
         self._kwargs = kwargs
-        self._repr_format = form
+        self._repr_format = format
         self.canvas = Canvas(cbar=cbar,
                              aspect=aspect,
                              grid=grid,

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -57,6 +57,10 @@ class Figure2d(BaseFig):
     cax:
         If supplied, use these axes for the colorbar. If none are supplied, and a
         colorbar is required, the canvas will create its own axes.
+    form:
+        Format of the figure displayed in the Jupyter notebook. If ``None``, a SVG is
+        created as long as the number of markers in the figure is not too large. If too
+        many markers are drawn, a PNG image is created instead.
     **kwargs:
         All other kwargs are forwarded to the Mesh artist.
     """
@@ -77,12 +81,14 @@ class Figure2d(BaseFig):
                  figsize: Tuple[float, float] = (6., 4.),
                  ax: Any = None,
                  cax: Any = None,
+                 form: Literal['svg', 'png'] = None,
                  **kwargs):
 
         super().__init__(*nodes)
 
         self._scale = {} if scale is None else scale
         self._kwargs = kwargs
+        self._repr_format = form
         self.canvas = Canvas(cbar=cbar,
                              aspect=aspect,
                              grid=grid,

--- a/src/plopp/graphics/static.py
+++ b/src/plopp/graphics/static.py
@@ -34,7 +34,7 @@ class Static:
             npoints = 0
             for line in self.canvas.ax.lines:
                 npoints += len(line.get_xdata())
-            repr_maker = REPR_MAP['png' if (npoints > 60_000) else 'svg']
+            repr_maker = REPR_MAP['png' if (npoints > 20_000) else 'svg']
         out.update(repr_maker(self.canvas.fig))
         return out
 

--- a/src/plopp/graphics/static.py
+++ b/src/plopp/graphics/static.py
@@ -6,6 +6,17 @@ from .fig2d import Figure2d
 from .utils import fig_to_bytes
 
 
+def _make_png_repr(fig):
+    return {'image/png': fig_to_bytes(fig, form='png')}
+
+
+def _make_svg_repr(fig):
+    return {'image/svg+xml': fig_to_bytes(fig, form='svg').decode()}
+
+
+REPR_MAP = {'png': _make_png_repr, 'svg': _make_svg_repr}
+
+
 class Static:
     """
     Mixin class to provide the svg repr for static figures, as well as a method to
@@ -16,10 +27,16 @@ class Static:
         """
         Mimebundle display representation for jupyter notebooks.
         """
-        return {
-            'text/plain': 'Figure',
-            'image/svg+xml': fig_to_bytes(self.canvas.fig, form='svg').decode()
-        }
+        out = {'text/plain': 'Figure'}
+        if self._repr_format is not None:
+            repr_maker = REPR_MAP[self._repr_format.lower()]
+        else:
+            npoints = 0
+            for line in self.canvas.ax.lines:
+                npoints += len(line.get_xdata())
+            repr_maker = REPR_MAP['png' if (npoints > 60_000) else 'svg']
+        out.update(repr_maker(self.canvas.fig))
+        return out
 
     def to_widget(self):
         """


### PR DESCRIPTION
Use a switch to a PNG repr if there are too many points or lines drawn on the figure, as rendering the full SVG slows down the notebook.
One can forcibly request a format by using
```Py
pp.plot(da, form='svg')
```

Fix #78 