### PR TITLE
Fixes for scatter3d plots

### DIFF
--- a/src/plopp/functions/scatter3d.py
+++ b/src/plopp/functions/scatter3d.py
@@ -5,6 +5,7 @@ from ..core import input_node
 
 import scipp as sc
 from typing import Literal, Tuple, Union
+import uuid
 
 
 def scatter3d(da: sc.DataArray,
@@ -76,8 +77,10 @@ def scatter3d(da: sc.DataArray,
     else:
         coords = {k: da.meta[k] for k in (x, y, z)}
 
-    fig = figure3d(input_node(sc.DataArray(data=da.data, masks=da.masks,
-                                           coords=coords)),
+    to_plot = sc.DataArray(data=da.data, masks=da.masks, coords=coords)
+    if to_plot.ndim > 1:
+        to_plot = to_plot.flatten(to=uuid.uuid4().hex)
+    fig = figure3d(input_node(to_plot),
                    x=x,
                    y=y,
                    z=z,

--- a/src/plopp/graphics/point_cloud.py
+++ b/src/plopp/graphics/point_cloud.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from ..core.limits import find_limits, fix_empty_range
-
 import numpy as np
 import scipp as sc
 from typing import Tuple

--- a/src/plopp/graphics/point_cloud.py
+++ b/src/plopp/graphics/point_cloud.py
@@ -46,6 +46,7 @@ class PointCloud:
         self._x = x
         self._y = y
         self._z = z
+        self._pixel_size = pixel_size
 
         self.geometry = p3.BufferGeometry(
             attributes={
@@ -65,7 +66,7 @@ class PointCloud:
         # Note that an additional factor of 2.5 (obtained from trial and error) seems to
         # be required to get the sizes right in the scene.
         self.material = p3.PointsMaterial(vertexColors='VertexColors',
-                                          size=2.5 * pixel_size * pixel_ratio,
+                                          size=2.5 * self._pixel_size * pixel_ratio,
                                           transparent=True,
                                           opacity=opacity)
         self.points = p3.Points(geometry=self.geometry, material=self.material)
@@ -96,12 +97,16 @@ class PointCloud:
         """
         Get the spatial extent of all the points in the cloud.
         """
-        xmin, xmax = fix_empty_range(find_limits(self._data.meta[self._x]))
-        ymin, ymax = fix_empty_range(find_limits(self._data.meta[self._y]))
-        zmin, zmax = fix_empty_range(find_limits(self._data.meta[self._z]))
-        return (sc.concat([xmin, xmax],
-                          dim=self._x), sc.concat([ymin, ymax], dim=self._y),
-                sc.concat([zmin, zmax], dim=self._z))
+        xcoord = self._data.meta[self._x]
+        ycoord = self._data.meta[self._y]
+        zcoord = self._data.meta[self._z]
+        half_pixel = 0.5 * self._pixel_size
+        dx = sc.scalar(half_pixel, unit=xcoord.unit)
+        dy = sc.scalar(half_pixel, unit=ycoord.unit)
+        dz = sc.scalar(half_pixel, unit=zcoord.unit)
+        return (sc.concat([xcoord.min() - dx, xcoord.max() + dx], dim=self._x),
+                sc.concat([ycoord.min() - dy, ycoord.max() + dy], dim=self._y),
+                sc.concat([zcoord.min() - dz, zcoord.max() + dz], dim=self._z))
 
     @property
     def opacity(self):

--- a/tests/functions/scatter3d_test.py
+++ b/tests/functions/scatter3d_test.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
+import numpy as np
 import plopp as pp
 from plopp.data import scatter_data
 import pytest
+import scipp as sc
 
 
 def test_scatter3d_from_pos():
@@ -22,3 +24,21 @@ def test_scatter3d_raises_with_both_pos_and_xyz():
         pp.scatter3d(da, pos='position', x='x', y='y', z='z')
     assert str(e.value) == ('If pos (position) is defined, all of '
                             'x (x), y (y), and z (z) must be None.')
+
+
+def test_scatter3d_dimensions_are_flattened():
+    nx = 12
+    ny = 12
+    x = sc.linspace(dim='x', start=-10.0, stop=10.0, num=nx, unit='m')
+    y = sc.linspace(dim='y', start=-10.0, stop=10.0, num=ny, unit='m')
+    da = sc.DataArray(data=sc.array(dims=['x', 'y'], values=np.random.rand(nx, ny)),
+                      coords={'position': sc.geometry.position(x, y, 0.0 * sc.units.m)})
+    p = pp.scatter3d(da, pos="position")
+    assert list(p.children[0].artists.values())[0].data.ndim == 1
+    nz = 12
+    z = sc.linspace(dim='z', start=-10.0, stop=10.0, num=nz, unit='m')
+    da = sc.DataArray(data=sc.array(dims=['x', 'y', 'z'],
+                                    values=np.random.rand(nx, ny, nz)),
+                      coords={'position': sc.geometry.position(x, y, z)})
+    p = pp.scatter3d(da, pos="position")
+    assert list(p.children[0].artists.values())[0].data.ndim == 1

--- a/tests/graphics/point_cloud_test.py
+++ b/tests/graphics/point_cloud_test.py
@@ -27,11 +27,26 @@ def test_update():
 
 def test_get_limits():
     da = scatter_data()
-    cloud = PointCloud(data=da, x='x', y='y', z='z')
+    pix = 0.5
+    cloud = PointCloud(data=da, x='x', y='y', z='z', pixel_size=pix)
     xlims, ylims, zlims = cloud.get_limits()
-    assert sc.identical(xlims[0], da.meta['x'].min())
-    assert sc.identical(xlims[1], da.meta['x'].max())
-    assert sc.identical(ylims[0], da.meta['y'].min())
-    assert sc.identical(ylims[1], da.meta['y'].max())
-    assert sc.identical(zlims[0], da.meta['z'].min())
-    assert sc.identical(zlims[1], da.meta['z'].max())
+    assert sc.identical(xlims[0], da.meta['x'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[1], da.meta['x'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[0], da.meta['y'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[1], da.meta['y'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(zlims[0], da.meta['z'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(zlims[1], da.meta['z'].max() + sc.scalar(0.5 * pix, unit='m'))
+
+
+def test_get_limits_flat_panel():
+    da = scatter_data()
+    da.coords['z'] *= 0.
+    pix = 0.5
+    cloud = PointCloud(data=da, x='x', y='y', z='z', pixel_size=pix)
+    xlims, ylims, zlims = cloud.get_limits()
+    assert sc.identical(xlims[0], da.meta['x'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[1], da.meta['x'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[0], da.meta['y'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[1], da.meta['y'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(zlims[0], sc.scalar(-0.5 * pix, unit='m'))
+    assert sc.identical(zlims[1], sc.scalar(0.5 * pix, unit='m'))


### PR DESCRIPTION
- Factor in pixel size to compute point cloud limits, so that a flat panel of pixels has correct size in all 3 directions
- Flatten input data with ndim > 1 so that 3d spatial cuts can work (selection broke down on multi-d coordinates)