### PR TITLE
Add method figure to save figures to disk

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,7 @@ Get in touch
    user-guide/inspector-plot
    user-guide/super-plot
    user-guide/scatter3d-plot
+   user-guide/saving-figures
 
 .. toctree::
    :caption: Custom figures

--- a/docs/user-guide/saving-figures.ipynb
+++ b/docs/user-guide/saving-figures.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "482f10de-b81d-4955-b50e-e5897d219799",
+   "metadata": {},
+   "source": [
+    "# Saving figures to disk\n",
+    "\n",
+    "To save a figure to disk, the `save` method should be called on the figure after creation.\n",
+    "Saving figures is available for one and two-dimensional figures.\n",
+    "Possible file formats are `.png`, `.pdf`, `.jpg`, and `.svg`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0479061c-bd9b-4e77-9da8-49799bb2749e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plopp as pp\n",
+    "\n",
+    "da1d = pp.data.data_array(ndim=1)\n",
+    "f1d = pp.plot(da1d)\n",
+    "f1d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b370edbc-5fe2-4ab3-9b4d-cce0bb5ea76f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f1d.save('fig.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "024f92db-e307-4aa8-bb09-37024a7b8ac6",
+   "metadata": {},
+   "source": [
+    "## A note on widgets\n",
+    "\n",
+    "When using the interactive plotting backend `%matplotlib widget`,\n",
+    "a toolbar with buttons is displayed next to the figure in the notebook.\n",
+    "These buttons will not be included when saving the figure to disk,\n",
+    "only the graphics will make it to the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ae86d91-0be9-4bb0-9c8d-d77c2b48c799",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "da2d = pp.data.data_array(ndim=2)\n",
+    "f2d = pp.plot(da2d)\n",
+    "f2d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ccab7ee-8ba0-41d1-a320-8e58a1b6bc05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f2d.save('fig2d.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b0b954-fd57-4062-b375-eed7ab97cd9e",
+   "metadata": {},
+   "source": [
+    "## Saving 3D scatter plots\n",
+    "\n",
+    "Saving three-dimensional scatter plots to disk is currently not implemented.\n",
+    "We currently recommend to take a static screenshot of the figure.\n",
+    "Saving the three-dimensional views as an interactive file is planned in the future."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/plopp/graphics/canvas.py
+++ b/src/plopp/graphics/canvas.py
@@ -165,8 +165,8 @@ class Canvas:
         Parameters
         ----------
         filename:
-            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
-            and ``.pdf``.
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, and ``.pdf``.
         """
         self.fig.savefig(filename, **{**{'bbox_inches': 'tight'}, **kwargs})
 

--- a/src/plopp/graphics/canvas.py
+++ b/src/plopp/graphics/canvas.py
@@ -158,14 +158,14 @@ class Canvas:
 
     def savefig(self, filename: str, **kwargs):
         """
-        Save plot to file.
+        Save the figure to file.
         The default directory for writing the file is the same as the
         directory where the script or notebook is running.
 
         Parameters
         ----------
         filename:
-            Save the figure to file. Possible file extensions are ``.jpg``, ``.png``
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
             and ``.pdf``.
         """
         self.fig.savefig(filename, **{**{'bbox_inches': 'tight'}, **kwargs})
@@ -250,7 +250,7 @@ class Canvas:
         """
         self.fig.canvas.toolbar.pan()
 
-    def save(self):
+    def save_figure(self):
         """
         Save the figure to a PNG file via a pop-up dialog.
         """

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -172,7 +172,7 @@ class Figure1d(BaseFig):
         Parameters
         ----------
         filename:
-            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
-            and ``.pdf``.
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, and ``.pdf``.
         """
         self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -162,3 +162,17 @@ class Figure1d(BaseFig):
     @property
     def ax(self):
         return self.canvas.ax
+
+    def save(self, filename: str, **kwargs):
+        """
+        Save the figure to file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
+            and ``.pdf``.
+        """
+        self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -191,7 +191,7 @@ class Figure2d(BaseFig):
         Parameters
         ----------
         filename:
-            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
-            and ``.pdf``.
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, and ``.pdf``.
         """
         self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -181,3 +181,17 @@ class Figure2d(BaseFig):
     @property
     def cax(self):
         return self.canvas.cax
+
+    def save(self, filename: str, **kwargs):
+        """
+        Save the figure to file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``
+            and ``.pdf``.
+        """
+        self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/graphics/interactive.py
+++ b/src/plopp/graphics/interactive.py
@@ -31,7 +31,7 @@ class InteractiveFig1d(VBox):
                 tools.LogyTool(self._fig.canvas.logy,
                                value=self._fig.canvas.yscale == 'log'),
                 'save':
-                tools.SaveTool(self._fig.canvas.save)
+                tools.SaveTool(self._fig.canvas.save_figure)
             })
 
         self.left_bar = VBar([self.toolbar])
@@ -82,7 +82,7 @@ class InteractiveFig2d(VBox):
                 tools.LogNormTool(self._fig.toggle_norm,
                                   value=self._fig.colormapper.norm == 'log'),
                 'save':
-                tools.SaveTool(self._fig.canvas.save)
+                tools.SaveTool(self._fig.canvas.save_figure)
             })
 
         self.left_bar = VBar([self.toolbar])

--- a/tests/graphics/canvas_test.py
+++ b/tests/graphics/canvas_test.py
@@ -3,6 +3,8 @@
 
 from plopp.graphics.canvas import Canvas
 import scipp as sc
+import tempfile
+import os
 
 
 def test_creation():
@@ -83,3 +85,11 @@ def test_crop_no_variable():
     })
     assert canvas.ax.get_xlim() == (xmin, xmax)
     assert canvas.ax.get_ylim() == (ymin, ymax)
+
+
+def test_save_to_disk():
+    canvas = Canvas()
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, 'plopp_fig.pdf')
+        canvas.savefig(filename=fname)
+        assert os.path.isfile(fname)

--- a/tests/graphics/canvas_test.py
+++ b/tests/graphics/canvas_test.py
@@ -3,6 +3,7 @@
 
 from plopp.graphics.canvas import Canvas
 import scipp as sc
+import pytest
 import tempfile
 import os
 
@@ -87,9 +88,10 @@ def test_crop_no_variable():
     assert canvas.ax.get_ylim() == (ymin, ymax)
 
 
-def test_save_to_disk():
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk(ext):
     canvas = Canvas()
     with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, 'plopp_fig.pdf')
+        fname = os.path.join(path, f'plopp_fig.{ext}')
         canvas.savefig(filename=fname)
         assert os.path.isfile(fname)

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -186,10 +186,11 @@ def test_ax():
     assert len(ax.lines) > 0
 
 
-def test_save_to_disk():
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk(ext):
     da = data_array(ndim=1)
     fig = Figure1d(input_node(da))
     with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, 'plopp_fig1d.pdf')
+        fname = os.path.join(path, f'plopp_fig1d.{ext}')
         fig.save(filename=fname)
         assert os.path.isfile(fname)

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -9,6 +9,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipp as sc
 import pytest
+import tempfile
+import os
 
 
 def test_empty():
@@ -182,3 +184,12 @@ def test_ax():
     da = data_array(ndim=1)
     _ = Figure1d(input_node(da), ax=ax)
     assert len(ax.lines) > 0
+
+
+def test_save_to_disk():
+    da = data_array(ndim=1)
+    fig = Figure1d(input_node(da))
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, 'plopp_fig1d.pdf')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -9,6 +9,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipp as sc
 import pytest
+import tempfile
+import os
 
 
 def test_empty():
@@ -200,3 +202,12 @@ def test_cax():
     da = data_array(ndim=2)
     _ = Figure2d(input_node(da), ax=ax, cax=cax)
     assert len(cax.collections) > 0
+
+
+def test_save_to_disk():
+    da = data_array(ndim=2)
+    fig = Figure2d(input_node(da))
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, 'plopp_fig2d.pdf')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)

--- a/tests/graphics/fig2d_test.py
+++ b/tests/graphics/fig2d_test.py
@@ -204,10 +204,11 @@ def test_cax():
     assert len(cax.collections) > 0
 
 
-def test_save_to_disk():
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk(ext):
     da = data_array(ndim=2)
     fig = Figure2d(input_node(da))
     with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, 'plopp_fig2d.pdf')
+        fname = os.path.join(path, f'plopp_fig2d.{ext}')
         fig.save(filename=fname)
         assert os.path.isfile(fname)


### PR DESCRIPTION
Until now, one had to go through `fig.canvas.savefig(filename)` to save figures to disk.
This adds the `fig.save(filename)` method to hide unnecessary implementation details from the user.