### PR TITLE
Check dims and units of updated values sent to figures, and perform on-the-fly conversions where possible

### DIFF
--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -182,4 +182,4 @@ def check_dim_and_maybe_convert_unit(x: sc.Variable, dim: str, unit: str):
     if x.dim != dim:
         raise sc.DimensionError(f'The supplied variable has dimension {x.dim} which is '
                                 f'incompatible with the requested dimension {dim}.')
-    return x.to(unit=unit, copy=False)
+    return x.to(unit=unit, copy=False) if unit is not None else x

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -171,3 +171,15 @@ def coord_element_to_string(x: sc.Variable) -> str:
     if x.unit is not None:
         out += f" [{x.unit}]"
     return out
+
+
+def check_dim_and_maybe_convert_unit(x: sc.Variable, unit: str, dim: str = None):
+    """
+    Raise exception if the dimension of the supplied variable is different from the
+    requested dimension.
+    Then, if the variable unit differs from the requested unit, attempt a conversion.
+    """
+    if (dim is not None) and (x.dim != dim):
+        raise sc.DimensionError(f'The supplied variable has dimension {x.dim} which is '
+                                f'incompatible with the requested dimension {dim}.')
+    return x.to(unit=unit, copy=False)

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -182,4 +182,9 @@ def check_dim_and_maybe_convert_unit(x: sc.Variable, dim: str, unit: str):
     if x.dim != dim:
         raise sc.DimensionError(f'The supplied variable has dimension {x.dim} which is '
                                 f'incompatible with the requested dimension {dim}.')
-    return x.to(unit=unit, copy=False) if unit is not None else x
+    if unit is not None:
+        return x.to(unit=unit, copy=False)
+    if x.unit is not None:
+        raise sc.UnitError(f'The supplied variable has unit {x.unit} which is '
+                           'incompatible with the requested unit None.')
+    return x

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -173,13 +173,13 @@ def coord_element_to_string(x: sc.Variable) -> str:
     return out
 
 
-def check_dim_and_maybe_convert_unit(x: sc.Variable, unit: str, dim: str = None):
+def check_dim_and_maybe_convert_unit(x: sc.Variable, dim: str, unit: str):
     """
     Raise exception if the dimension of the supplied variable is different from the
     requested dimension.
     Then, if the variable unit differs from the requested unit, attempt a conversion.
     """
-    if (dim is not None) and (x.dim != dim):
+    if x.dim != dim:
         raise sc.DimensionError(f'The supplied variable has dimension {x.dim} which is '
                                 f'incompatible with the requested dimension {dim}.')
     return x.to(unit=unit, copy=False)

--- a/src/plopp/graphics/canvas3d.py
+++ b/src/plopp/graphics/canvas3d.py
@@ -29,6 +29,9 @@ class Canvas3d:
 
         import pythreejs as p3
 
+        self.xunit = None
+        self.yunit = None
+        self.zunit = None
         self.outline = None
         self.axticks = None
         self.figsize = figsize

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -206,8 +206,8 @@ class ColorMapper:
         key:
             The id of the node that provided this data.
         """
-        if self.unit is None:
-            self.unit = data.unit
+        if self.name is None:
+            # self.unit = data.unit
             self.name = data.name
             if self.cax is not None:
                 self.cax.set_ylabel(f'{self.name} [{self.unit}]')

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -207,7 +207,8 @@ class ColorMapper:
             The id of the node that provided this data.
         """
         if self.name is None:
-            # self.unit = data.unit
+            if self.unit is None:
+                self.unit = data.unit
             self.name = data.name
             if self.cax is not None:
                 self.cax.set_ylabel(f'{self.name} [{self.unit}]')

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -124,8 +124,7 @@ class Figure1d(BaseFig):
             self.canvas.xunit = coord.unit
             self.canvas.yunit = new_values.unit
         else:
-            new_values.data = check_dim_and_maybe_convert_unit(new_values.data,
-                                                               unit=self.canvas.yunit)
+            new_values.data = new_values.data.to(unit=self.canvas.yunit, copy=False)
             new_values.coords[dim] = check_dim_and_maybe_convert_unit(
                 coord, dim=self.dims['x'], unit=self.canvas.xunit)
 

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -119,7 +119,7 @@ class Figure1d(BaseFig):
 
         dim = new_values.dim
         coord = new_values.coords[dim]
-        if 'x' not in self.dims:
+        if not self.dims:
             self.dims['x'] = dim
             self.canvas.xunit = coord.unit
             self.canvas.yunit = new_values.unit

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -128,10 +128,28 @@ class Figure1d(BaseFig):
             self.artists[key] = line
             if line.label:
                 self.canvas.legend()
-            self.dims['x'] = new_values.dim
+            if 'x' not in self.dims:
+                self.dims['x'] = new_values.dim
+            elif self.dims['x'] != new_values.dim:
+                raise sc.DimensionError(
+                    f'The supplied data has dimension {new_values.dim} which is '
+                    f'incompatible with the figure dimension {self.dims["x"]}.')
 
-            self.canvas.xunit = new_values.meta[new_values.dim].unit
-            self.canvas.yunit = new_values.unit
+            if self.canvas.xunit is None:
+                self.canvas.xunit = new_values.meta[new_values.dim].unit
+            elif self.canvas.xunit != new_values.meta[new_values.dim].unit:
+                raise sc.UnitError(
+                    f'The supplied data coordinate for the horizontal axis has unit '
+                    f'{new_values.meta[new_values.dim].unit} which is incompatible '
+                    f'with the figure X-axis units {self.canvas.xunit}.')
+
+            if self.canvas.yunit is None:
+                self.canvas.yunit = new_values.unit
+            elif self.canvas.yunit != new_values.unit:
+                raise sc.UnitError(
+                    f'The supplied data has unit {new_values.unit} which is '
+                    f'incompatible with the figure Y-axis units {self.canvas.yunit}.')
+
             self.canvas.xlabel = name_with_unit(var=new_values.meta[self.dims['x']])
             self.canvas.ylabel = name_with_unit(var=new_values.data, name="")
 

--- a/src/plopp/graphics/fig1d.py
+++ b/src/plopp/graphics/fig1d.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from ..core.utils import name_with_unit, check_dim_and_maybe_convert_unit
+from ..core.utils import name_with_unit, make_compatible
 from .basefig import BaseFig
 from .canvas import Canvas
 from .line import Line
@@ -124,9 +124,10 @@ class Figure1d(BaseFig):
             self.canvas.xunit = coord.unit
             self.canvas.yunit = new_values.unit
         else:
-            new_values.data = new_values.data.to(unit=self.canvas.yunit, copy=False)
-            new_values.coords[dim] = check_dim_and_maybe_convert_unit(
-                coord, dim=self.dims['x'], unit=self.canvas.xunit)
+            new_values.data = make_compatible(new_values.data, unit=self.canvas.yunit)
+            new_values.coords[dim] = make_compatible(coord,
+                                                     dim=self.dims['x'],
+                                                     unit=self.canvas.xunit)
 
         if key not in self.artists:
 

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from ..core.utils import name_with_unit, check_dim_and_maybe_convert_unit
+from ..core.utils import name_with_unit, make_compatible
 from .basefig import BaseFig
 from .canvas import Canvas
 from .colormapper import ColorMapper
@@ -138,11 +138,14 @@ class Figure2d(BaseFig):
             self.canvas.yunit = ycoord.unit
             self.colormapper.unit = new_values.unit
         else:
-            new_values.data = new_values.data.to(unit=self.colormapper.unit, copy=False)
-            new_values.coords[xdim] = check_dim_and_maybe_convert_unit(
-                xcoord, dim=self.dims['x'], unit=self.canvas.xunit)
-            new_values.coords[ydim] = check_dim_and_maybe_convert_unit(
-                ycoord, dim=self.dims['y'], unit=self.canvas.yunit)
+            new_values.data = make_compatible(new_values.data,
+                                              unit=self.colormapper.unit)
+            new_values.coords[xdim] = make_compatible(xcoord,
+                                                      dim=self.dims['x'],
+                                                      unit=self.canvas.xunit)
+            new_values.coords[ydim] = make_compatible(ycoord,
+                                                      dim=self.dims['y'],
+                                                      unit=self.canvas.yunit)
 
         self.colormapper.update(data=new_values, key=key)
 

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -138,8 +138,7 @@ class Figure2d(BaseFig):
             self.canvas.yunit = ycoord.unit
             self.colormapper.unit = new_values.unit
         else:
-            new_values.data = check_dim_and_maybe_convert_unit(
-                new_values.data, unit=self.colormapper.unit)
+            new_values.data = new_values.data.to(unit=self.colormapper.unit, copy=False)
             new_values.coords[xdim] = check_dim_and_maybe_convert_unit(
                 xcoord, dim=self.dims['x'], unit=self.canvas.xunit)
             new_values.coords[ydim] = check_dim_and_maybe_convert_unit(

--- a/src/plopp/graphics/fig2d.py
+++ b/src/plopp/graphics/fig2d.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from ..core.utils import name_with_unit
+from ..core.utils import name_with_unit, check_dim_and_maybe_convert_unit
 from .basefig import BaseFig
 from .canvas import Canvas
 from .colormapper import ColorMapper
@@ -128,6 +128,23 @@ class Figure2d(BaseFig):
         if new_values.ndim != 2:
             raise ValueError("Figure2d can only be used to plot 2-D data.")
 
+        xdim = new_values.dims[1]
+        xcoord = new_values.coords[xdim]
+        ydim = new_values.dims[0]
+        ycoord = new_values.coords[ydim]
+        if not self.dims:
+            self.dims.update({"x": xdim, "y": ydim})
+            self.canvas.xunit = xcoord.unit
+            self.canvas.yunit = ycoord.unit
+            self.colormapper.unit = new_values.unit
+        else:
+            new_values.data = check_dim_and_maybe_convert_unit(
+                new_values.data, unit=self.colormapper.unit)
+            new_values.coords[xdim] = check_dim_and_maybe_convert_unit(
+                xcoord, dim=self.dims['x'], unit=self.canvas.xunit)
+            new_values.coords[ydim] = check_dim_and_maybe_convert_unit(
+                ycoord, dim=self.dims['y'], unit=self.canvas.yunit)
+
         self.colormapper.update(data=new_values, key=key)
 
         if key not in self.artists:
@@ -139,6 +156,7 @@ class Figure2d(BaseFig):
 
             self.canvas.xunit = new_values.meta[new_values.dims[1]].unit
             self.canvas.yunit = new_values.meta[new_values.dims[0]].unit
+
             self.canvas.xlabel = name_with_unit(var=new_values.meta[self.dims['x']])
             self.canvas.ylabel = name_with_unit(var=new_values.meta[self.dims['y']])
             if self.dims['x'] in self._scale:

--- a/src/plopp/graphics/fig3d.py
+++ b/src/plopp/graphics/fig3d.py
@@ -95,6 +95,28 @@ class Figure3d(BaseFig):
             This argument is ignored for the 3d figure update.
         """
 
+        xcoord = new_values.coords[self._x]
+        ycoord = new_values.coords[self._y]
+        zcoord = new_values.coords[self._z]
+        if not self.dims:
+            self.dims.update({'x': self._x, 'y': self._y, 'z': self._z})
+            self.canvas.xunit = xcoord.unit
+            self.canvas.yunit = ycoord.unit
+            self.canvas.zunit = zcoord.unit
+            self.colormapper.unit = new_values.unit
+        else:
+            new_values.data = new_values.data.to(unit=self.colormapper.unit, copy=False)
+            new_values.coords[self._x] = new_values.coords[self._x].to(
+                unit=self.canvas.xunit, copy=False)
+            new_values.coords[self._y] = new_values.coords[self._y].to(
+                unit=self.canvas.yunit, copy=False)
+            new_values.coords[self._z] = new_values.coords[self._z].to(
+                unit=self.canvas.zunit, copy=False)
+            # new_values.coords[self._y] = check_dim_and_maybe_convert_unit(
+            #     ycoord, dim=self.dims['y'], unit=self.canvas.yunit)
+            # new_values.coords[self._z] = check_dim_and_maybe_convert_unit(
+            #     zcoord, dim=self.dims['z'], unit=self.canvas.zunit)
+
         self.colormapper.update(data=new_values, key=key)
 
         if key not in self.artists:

--- a/src/plopp/graphics/fig3d.py
+++ b/src/plopp/graphics/fig3d.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
+from ..core.utils import make_compatible
 from .basefig import BaseFig
 from .canvas3d import Canvas3d
 from .colormapper import ColorMapper
@@ -105,17 +106,14 @@ class Figure3d(BaseFig):
             self.canvas.zunit = zcoord.unit
             self.colormapper.unit = new_values.unit
         else:
-            new_values.data = new_values.data.to(unit=self.colormapper.unit, copy=False)
+            new_values.data = make_compatible(new_values.data,
+                                              unit=self.colormapper.unit)
             new_values.coords[self._x] = new_values.coords[self._x].to(
                 unit=self.canvas.xunit, copy=False)
             new_values.coords[self._y] = new_values.coords[self._y].to(
                 unit=self.canvas.yunit, copy=False)
             new_values.coords[self._z] = new_values.coords[self._z].to(
                 unit=self.canvas.zunit, copy=False)
-            # new_values.coords[self._y] = check_dim_and_maybe_convert_unit(
-            #     ycoord, dim=self.dims['y'], unit=self.canvas.yunit)
-            # new_values.coords[self._z] = check_dim_and_maybe_convert_unit(
-            #     zcoord, dim=self.dims['z'], unit=self.canvas.zunit)
 
         self.colormapper.update(data=new_values, key=key)
 

--- a/tests/core/utils_test.py
+++ b/tests/core/utils_test.py
@@ -58,29 +58,3 @@ def test_coord_as_bin_edges_non_dimension_coord():
                       })
     result = coord_as_bin_edges(da, key='y', dim='x')
     assert sc.identical(result, sc.linspace('x', 16.5, 21.5, num=6, unit='m'))
-
-
-def test_make_compatible_raises_different_dimension():
-    x = sc.arange('x', 6., unit='m')
-    with pytest.raises(sc.DimensionError):
-        make_compatible(x, dim='y', unit='m')
-
-
-def test_make_compatible_raises_incompatible_unit():
-    x = sc.arange('x', 6., unit='m')
-    with pytest.raises(sc.UnitError):
-        make_compatible(x, unit='s')
-
-
-def test_make_compatible_comverts_compatible_unit():
-    x = sc.array(dims=['x'], values=[1., 4., 9.], unit='s')
-    expected = sc.array(dims=['x'], values=[1000., 4000., 9000.], unit='ms')
-    result = make_compatible(x, unit='ms')
-    assert sc.identical(result, expected)
-
-
-def test_make_compatible_comverts_compatible_unit_integers():
-    x = sc.array(dims=['x'], values=[10, 20, 30, 40, 50], unit='cm')
-    expected = sc.array(dims=['x'], values=[0.1, 0.2, 0.3, 0.4, 0.5], unit='m')
-    result = make_compatible(x, unit='m')
-    assert sc.identical(result, expected)

--- a/tests/core/utils_test.py
+++ b/tests/core/utils_test.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from plopp.core.utils import coord_as_bin_edges, make_compatible
+from plopp.core.utils import coord_as_bin_edges
 import scipp as sc
-import pytest
 
 
 def test_coord_as_bin_edges_midpoints_input():

--- a/tests/core/utils_test.py
+++ b/tests/core/utils_test.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
-from plopp.core.utils import coord_as_bin_edges
+from plopp.core.utils import coord_as_bin_edges, make_compatible
 import scipp as sc
+import pytest
 
 
 def test_coord_as_bin_edges_midpoints_input():
@@ -57,3 +58,29 @@ def test_coord_as_bin_edges_non_dimension_coord():
                       })
     result = coord_as_bin_edges(da, key='y', dim='x')
     assert sc.identical(result, sc.linspace('x', 16.5, 21.5, num=6, unit='m'))
+
+
+def test_make_compatible_raises_different_dimension():
+    x = sc.arange('x', 6., unit='m')
+    with pytest.raises(sc.DimensionError):
+        make_compatible(x, dim='y', unit='m')
+
+
+def test_make_compatible_raises_incompatible_unit():
+    x = sc.arange('x', 6., unit='m')
+    with pytest.raises(sc.UnitError):
+        make_compatible(x, unit='s')
+
+
+def test_make_compatible_comverts_compatible_unit():
+    x = sc.array(dims=['x'], values=[1., 4., 9.], unit='s')
+    expected = sc.array(dims=['x'], values=[1000., 4000., 9000.], unit='ms')
+    result = make_compatible(x, unit='ms')
+    assert sc.identical(result, expected)
+
+
+def test_make_compatible_comverts_compatible_unit_integers():
+    x = sc.array(dims=['x'], values=[10, 20, 30, 40, 50], unit='cm')
+    expected = sc.array(dims=['x'], values=[0.1, 0.2, 0.3, 0.4, 0.5], unit='m')
+    result = make_compatible(x, unit='m')
+    assert sc.identical(result, expected)

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -216,3 +216,26 @@ def test_raises_for_new_data_with_incompatible_coord_unit():
     b.coords['xx'] = a.coords['xx'] * a.coords['xx']
     with pytest.raises(sc.UnitError):
         Figure1d(input_node(a), input_node(b))
+
+
+def test_converts_new_data_units():
+    a = data_array(ndim=1, unit='m')
+    b = data_array(ndim=1, unit='cm')
+    anode = input_node(a)
+    bnode = input_node(b)
+    fig = Figure1d(anode, bnode)
+    assert sc.identical(fig.artists[anode.id]._data, a)
+    assert sc.identical(fig.artists[bnode.id]._data, b.to(unit='m'))
+
+
+def test_converts_new_data_coordinate_units():
+    a = data_array(ndim=1)
+    b = data_array(ndim=1)
+    b.coords['xx'].unit = 'cm'
+    anode = input_node(a)
+    bnode = input_node(b)
+    fig = Figure1d(anode, bnode)
+    assert sc.identical(fig.artists[anode.id]._data, a)
+    c = b.copy()
+    c.coords['xx'] = c.coords['xx'].to(unit='m')
+    assert sc.identical(fig.artists[bnode.id]._data, c)

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -194,3 +194,25 @@ def test_save_to_disk(ext):
         fname = os.path.join(path, f'plopp_fig1d.{ext}')
         fig.save(filename=fname)
         assert os.path.isfile(fname)
+
+
+def test_raises_for_new_data_with_incompatible_dimension():
+    x = data_array(ndim=1)
+    y = x.rename(xx='yy')
+    with pytest.raises(sc.DimensionError):
+        Figure1d(input_node(x), input_node(y))
+
+
+def test_raises_for_new_data_with_incompatible_unit():
+    a = data_array(ndim=1)
+    b = a * a
+    with pytest.raises(sc.UnitError):
+        Figure1d(input_node(a), input_node(b))
+
+
+def test_raises_for_new_data_with_incompatible_coord_unit():
+    a = data_array(ndim=1)
+    b = a.copy()
+    b.coords['xx'] = a.coords['xx'] * a.coords['xx']
+    with pytest.raises(sc.UnitError):
+        Figure1d(input_node(a), input_node(b))

--- a/tests/graphics/fig1d_test.py
+++ b/tests/graphics/fig1d_test.py
@@ -239,3 +239,15 @@ def test_converts_new_data_coordinate_units():
     c = b.copy()
     c.coords['xx'] = c.coords['xx'].to(unit='m')
     assert sc.identical(fig.artists[bnode.id]._data, c)
+
+
+def test_converts_new_data_units_integers():
+    a = sc.DataArray(data=sc.array(dims=['x'], values=[1, 2, 3, 4, 5], unit='m'),
+                     coords={'x': sc.arange('x', 5., unit='s')})
+    b = sc.DataArray(data=sc.array(dims=['x'], values=[10, 20, 30, 40, 50], unit='cm'),
+                     coords={'x': sc.arange('x', 5., unit='s')})
+    anode = input_node(a)
+    bnode = input_node(b)
+    fig = Figure1d(anode, bnode)
+    assert sc.identical(fig.artists[anode.id]._data, a)
+    assert sc.identical(fig.artists[bnode.id]._data, b.to(unit='m', dtype=float))

--- a/tests/graphics/fig3d_test.py
+++ b/tests/graphics/fig3d_test.py
@@ -6,6 +6,7 @@ from plopp.graphics.fig3d import Figure3d
 from plopp.graphics.point_cloud import PointCloud
 from plopp import input_node
 import scipp as sc
+import pytest
 
 
 def test_creation():
@@ -30,3 +31,53 @@ def test_log_norm():
     da = scatter()
     fig = Figure3d(input_node(da), x='x', y='y', z='z', norm='log')
     assert fig.colormapper.norm == 'log'
+
+
+def test_raises_for_new_data_with_incompatible_coordinate():
+    a = scatter()
+    b = scatter()
+    b.coords['t'] = b.coords.pop('x')
+    with pytest.raises(KeyError):
+        Figure3d(input_node(a), input_node(b), x='x', y='y', z='z')
+
+
+def test_raises_for_new_data_with_incompatible_unit():
+    a = scatter()
+    b = a * a
+    with pytest.raises(sc.UnitError):
+        Figure3d(input_node(a), input_node(b), x='x', y='y', z='z')
+
+
+def test_raises_for_new_data_with_incompatible_coord_unit():
+    a = scatter()
+    b = a.copy()
+    b.coords['x'] = a.coords['x'] * a.coords['x']
+    with pytest.raises(sc.UnitError):
+        Figure3d(input_node(a), input_node(b), x='x', y='y', z='z')
+
+
+def test_converts_new_data_units():
+    a = scatter()
+    a.unit = 'm'
+    b = scatter()
+    b.unit = 'cm'
+    anode = input_node(a)
+    bnode = input_node(b)
+    fig = Figure3d(anode, bnode, x='x', y='y', z='z')
+    assert sc.identical(fig.artists[anode.id]._data, a)
+    assert sc.identical(fig.artists[bnode.id]._data, b.to(unit='m'))
+
+
+def test_converts_new_data_coordinate_units():
+    a = scatter()
+    b = scatter()
+    xcoord = b.coords['x'].copy()
+    xcoord.unit = 'cm'
+    b.coords['x'] = xcoord
+    anode = input_node(a)
+    bnode = input_node(b)
+    fig = Figure3d(anode, bnode, x='x', y='y', z='z')
+    assert sc.identical(fig.artists[anode.id]._data, a)
+    c = b.copy()
+    c.coords['x'] = c.coords['x'].to(unit='m')
+    assert sc.identical(fig.artists[bnode.id]._data, c)


### PR DESCRIPTION
Wth these changes:
- adding new data to an existing figure with dimensions that differ from, or units that are incompatible with, what is already on the figure will raise an exception
- adding new data to an existing figure with units that can be converted to the units of the data already on the figure will perform the conversion on-the-fly

Examples:
```Py
x = sc.array(dims=['x'], values=[1, 2, 3, 4, 5], unit='m')
y = sc.array(dims=['y'], values=[1, 2, 3, 4, 5], unit='m')
pp.plot({'x': x, 'y': y})  # Raises a DimensionError
```

```Py
a = sc.array(dims=['x'], values=[1, 2, 3, 4, 5], unit='m')
b = sc.array(dims=['x'], values=[50., 100., 150., 200., 250.], unit='s')
pp.plot({'a': a, 'b': b})  # Raises a UnitError
```

```Py
a = sc.array(dims=['x'], values=[1, 2, 3, 4, 5], unit='m')
b = sc.array(dims=['x'], values=[50., 100., 150., 200., 250.], unit='cm')
pp.plot({'a': a, 'b': b})  # scales the values of `b` correctly
```
![Screenshot at 2022-12-15 13-50-56](https://user-images.githubusercontent.com/39047984/207863528-a1085689-3851-4db8-80e4-1da79f64216b.png)

Note that in the second example, the order matters: the first entry in the dict decides the unit for the axes.

Fixes #122 