### PR TITLE
Make VBar and HBar indexable 

### DIFF
--- a/src/plopp/functions/superplot.py
+++ b/src/plopp/functions/superplot.py
@@ -27,7 +27,7 @@ class LineSaveTool:
 
     def __init__(self, data_node: Node, slider_node: Node, fig: View):
         import ipywidgets as ipw
-        from .box import VBar
+        from ..widgets.box import VBar
         self._data_node = data_node
         self._slider_node = slider_node
         self._fig = fig

--- a/src/plopp/functions/superplot.py
+++ b/src/plopp/functions/superplot.py
@@ -27,14 +27,15 @@ class LineSaveTool:
 
     def __init__(self, data_node: Node, slider_node: Node, fig: View):
         import ipywidgets as ipw
+        from .box import VBar
         self._data_node = data_node
         self._slider_node = slider_node
         self._fig = fig
         self._lines = {}
         self.button = ipw.Button(description='Save line')
         self.button.on_click(self.save_line)
-        self.container = ipw.VBox()
-        self.widget = ipw.VBox([self.button, self.container], layout={'width': '350px'})
+        self.container = VBar()
+        self.widget = VBar([self.button, self.container], layout={'width': '350px'})
 
     def _update_container(self):
         self.container.children = [line['tool'] for line in self._lines.values()]

--- a/src/plopp/widgets/box.py
+++ b/src/plopp/widgets/box.py
@@ -9,8 +9,8 @@ class Bar:
     A simple mixin to provide add and remove helper methods for HBox/VBox containers.
     """
 
-    def __getitem__(self, ind):
-        return self.children[ind]
+    def __len__(self):
+        return len(self.children)
 
     def add(self, obj: Widget):
         """
@@ -31,14 +31,24 @@ class VBar(VBox, Bar):
     """
     Vertical bar container.
     """
-    pass
+
+    def __getitem__(self, ind):
+        if isinstance(ind, int):
+            return self.children[ind]
+        elif isinstance(ind, slice):
+            return VBar(self.children[ind])
 
 
 class HBar(HBox, Bar):
     """
     Horizontal bar container.
     """
-    pass
+
+    def __getitem__(self, ind):
+        if isinstance(ind, int):
+            return self.children[ind]
+        elif isinstance(ind, slice):
+            return HBar(self.children[ind])
 
 
 class Box(VBar):

--- a/src/plopp/widgets/box.py
+++ b/src/plopp/widgets/box.py
@@ -9,6 +9,9 @@ class Bar:
     A simple mixin to provide add and remove helper methods for HBox/VBox containers.
     """
 
+    def __getitem__(self, ind):
+        return self.children[ind]
+
     def add(self, obj: Widget):
         """
         Append a widget to the list of children.
@@ -38,7 +41,7 @@ class HBar(HBox, Bar):
     pass
 
 
-class Box(VBox):
+class Box(VBar):
     """
     Container widget that accepts a list of items. For each item in the list, if the
     item is itself a list, it will be made into a horizontal row of the underlying
@@ -53,8 +56,7 @@ class Box(VBox):
     """
 
     def __init__(self, widgets):
-        self.widgets = widgets
         children = []
-        for view in self.widgets:
-            children.append(HBox(view) if isinstance(view, (list, tuple)) else view)
+        for view in widgets:
+            children.append(HBar(view) if isinstance(view, (list, tuple)) else view)
         super().__init__(children)

--- a/src/plopp/widgets/slice.py
+++ b/src/plopp/widgets/slice.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
+from .box import VBar
 from ..core.utils import coord_element_to_string
 from ..core import node
 
@@ -9,7 +10,7 @@ import scipp as sc
 from typing import Any, Callable, Dict
 
 
-class SliceWidget(ipw.VBox):
+class SliceWidget(VBar):
     """
     Widgets containing a slider for each of the requested dimensions.
     The widget uses the input data array to determine the range each slider should have.
@@ -25,6 +26,7 @@ class SliceWidget(ipw.VBox):
     """
 
     def __init__(self, sizes: Dict[str, int], coords: Dict[str, sc.Variable]):
+
         self._slider_dims = list(sizes.keys())
         self.controls = {}
         self.view = None

--- a/tests/functions/scatter3d_test.py
+++ b/tests/functions/scatter3d_test.py
@@ -32,14 +32,14 @@ def test_scatter3d_dimensions_are_flattened():
     da = sc.DataArray(data=sc.array(dims=['x', 'y'], values=np.random.rand(nx, ny)),
                       coords={'position': sc.geometry.position(x, y, 0.0 * sc.units.m)})
     p = pp.scatter3d(da, pos="position")
-    assert list(p.children[0].artists.values())[0].data.ndim == 1
+    assert list(p[0].artists.values())[0].data.ndim == 1
     nz = 12
     z = sc.linspace(dim='z', start=-10.0, stop=10.0, num=nz, unit='m')
     da = sc.DataArray(data=sc.array(dims=['x', 'y', 'z'],
                                     values=np.random.rand(nx, ny, nz)),
                       coords={'position': sc.geometry.position(x, y, z)})
     p = pp.scatter3d(da, pos="position")
-    assert list(p.children[0].artists.values())[0].data.ndim == 1
+    assert list(p[0].artists.values())[0].data.ndim == 1
 
 
 def test_raises_ValueError_when_given_binned_data():

--- a/tests/widgets/box_test.py
+++ b/tests/widgets/box_test.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
+from plopp.widgets import VBar, HBar
+import ipywidgets as ipw
+import pytest
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_creation(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    bar = Bar([b1, b2])
+    assert len(bar.children) == 2
+    assert bar.children[0] is b1
+    assert bar.children[1] is b2
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_add(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    bar = Bar([b1])
+    assert len(bar.children) == 1
+    bar.add(b2)
+    assert len(bar.children) == 2
+    assert bar.children[0] is b1
+    assert bar.children[1] is b2
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_remove(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    bar = Bar([b1, b2])
+    assert len(bar.children) == 2
+    assert bar.children[0] is b1
+    assert bar.children[1] is b2
+    bar.remove(b1)
+    assert len(bar.children) == 1
+    assert bar.children[0] is b2
+    bar = Bar([b1, b2])
+    bar.remove(b2)
+    assert len(bar.children) == 1
+    assert bar.children[0] is b1
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_indexing(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    bar = Bar([b1, b2])
+    assert bar[0] is b1
+    assert bar[1] is b2
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_indexing_range(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    b3 = ipw.Button(description='Button 3')
+    bar = Bar([b1, b2, b3])
+    result = bar[1:3]
+    assert isinstance(result, Bar)
+    assert len(result.children) == 2
+    assert result.children[0] is b2
+    assert result.children[1] is b3
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_indexing_range_step(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    b3 = ipw.Button(description='Button 3')
+    bar = Bar([b1, b2, b3])
+    result = bar[0:3:2]
+    assert isinstance(result, Bar)
+    assert len(result.children) == 2
+    assert result.children[0] is b1
+    assert result.children[1] is b3
+
+
+@pytest.mark.parametrize('Bar', [VBar, HBar])
+def test_bar_length(Bar):
+    b1 = ipw.Button(description='Button 1')
+    b2 = ipw.Button(description='Button 2')
+    b3 = ipw.Button(description='Button 3')
+    bar = Bar([b1, b2, b3])
+    assert len(bar) == 3


### PR DESCRIPTION
`HBar` and `VBar` are our custom classes that implement ipywidgets' `HBox` and `VBox`.

Here we extend our classes by adding the possibility of getting the children of a `HBar` or `VBar` widget (and hence also the `Box`) using simple indexing, instead of having to go via `.children`.
This is useful for unit tests, or when looking at the different components of a visualization in a notebook.
