### PR TITLE
Save 3d figs to html

### DIFF
--- a/docs/basics/saving-figures.ipynb
+++ b/docs/basics/saving-figures.ipynb
@@ -74,14 +74,33 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38b0b954-fd57-4062-b375-eed7ab97cd9e",
+   "id": "74dce037-e979-4a41-be30-eb82007e4d36",
    "metadata": {},
    "source": [
     "## Saving 3D scatter plots\n",
     "\n",
-    "Saving three-dimensional scatter plots to disk is currently not implemented.\n",
-    "We currently recommend to take a static screenshot of the figure.\n",
-    "Saving the three-dimensional views as an interactive file is planned in the future."
+    "It also possible to save three-dimensional scatter plots to a standalone `.html` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7445224e-bedd-4002-b0e7-091aad715e2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f3d = pp.scatter3d(pp.data.scatter(), pos='position')\n",
+    "# Need index 0, as `scatter3d` returns a Box with the figure and cut3d tool\n",
+    "f3d[0].save('fig3d.html')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "618fe7bf-c9ae-4372-af42-e214b16ae980",
+   "metadata": {},
+   "source": [
+    "Saving three-dimensional scatter plots to static (e.g. `.png` images) is currently not implemented.\n",
+    "We recommend to take a static screenshot of the figure."
    ]
   }
  ],

--- a/docs/examples/gallery/masking-a-range.ipynb
+++ b/docs/examples/gallery/masking-a-range.ipynb
@@ -137,7 +137,7 @@
    "source": [
     "# This cell is used to generate the thumbnail for the docs gallery.\n",
     "# It is hidden from the online documentation.\n",
-    "fig2d.canvas.savefig('../../_static/gallery/masking-a-range-thumbnail.png')"
+    "fig2d.save('../../_static/gallery/masking-a-range-thumbnail.png')"
    ]
   }
  ],

--- a/docs/examples/gallery/nyc-taxi.ipynb
+++ b/docs/examples/gallery/nyc-taxi.ipynb
@@ -109,8 +109,8 @@
    "source": [
     "# This cell is used to generate the thumbnail for the docs gallery.\n",
     "# It is hidden from the online documentation.\n",
-    "fig2d.canvas.ax.set_aspect('equal')\n",
-    "fig2d.canvas.savefig('../../_static/gallery/nyc-taxi-thumbnail.png')"
+    "fig2d.ax.set_aspect('equal')\n",
+    "fig2d.save('../../_static/gallery/nyc-taxi-thumbnail.png')"
    ]
   }
  ],

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -170,7 +170,7 @@ class Canvas:
         """
         self.fig.canvas.draw_idle()
 
-    def savefig(self, filename: str, **kwargs):
+    def save(self, filename: str, **kwargs):
         """
         Save the figure to file.
         The default directory for writing the file is the same as the
@@ -325,7 +325,7 @@ class Canvas:
         elif value is None:
             self.reset_mode()
 
-    def save_figure(self):
+    def download_figure(self):
         """
         Save the figure to a PNG file via a pop-up dialog.
         """

--- a/src/plopp/backends/matplotlib/interactive.py
+++ b/src/plopp/backends/matplotlib/interactive.py
@@ -30,15 +30,24 @@ class InteractiveFig(VBox):
 
     @property
     def fig(self):
+        """
+        Get the underlying Matplotlib figure.
+        """
         return self._fig.canvas.fig
 
     @property
     def ax(self):
+        """
+        Get the underlying Matplotlib axes.
+        """
         return self._fig.canvas.ax
 
     @property
     def cax(self):
-        return self.canvas.cax
+        """
+        Get the underlying Matplotlib colorbar axes.
+        """
+        return self._fig.canvas.cax
 
     @property
     def canvas(self):
@@ -56,11 +65,30 @@ class InteractiveFig(VBox):
     def graph_nodes(self):
         return self._fig.graph_nodes
 
-    def crop(self, *args, **kwargs):
-        return self._fig.crop(*args, **kwargs)
+    def crop(self, **limits):
+        """
+        Set the axes limits according to the crop parameters.
 
-    def save(self, *args, **kwargs):
-        return self._fig.save(*args, **kwargs)
+        Parameters
+        ----------
+        **limits:
+            Min and max limits for each dimension to be cropped.
+        """
+        return self._fig.crop(**limits)
+
+    def save(self, filename, **kwargs):
+        """
+        Save the figure to file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, and ``.pdf``.
+        """
+        return self._fig.canvas.save(filename, **kwargs)
 
     def update(self, *args, **kwargs):
         return self._fig.update(*args, **kwargs)

--- a/src/plopp/backends/matplotlib/static.py
+++ b/src/plopp/backends/matplotlib/static.py
@@ -47,15 +47,24 @@ class StaticFig:
 
     @property
     def fig(self):
+        """
+        Get the underlying Matplotlib figure.
+        """
         return self._fig.canvas.fig
 
     @property
     def ax(self):
+        """
+        Get the underlying Matplotlib axes.
+        """
         return self._fig.canvas.ax
 
     @property
     def cax(self):
-        return self.canvas.cax
+        """
+        Get the underlying Matplotlib colorbar axes.
+        """
+        return self._fig.canvas.cax
 
     @property
     def canvas(self):
@@ -73,11 +82,30 @@ class StaticFig:
     def graph_nodes(self):
         return self._fig.graph_nodes
 
-    def crop(self, *args, **kwargs):
-        return self._fig.crop(*args, **kwargs)
+    def crop(self, **limits):
+        """
+        Set the axes limits according to the crop parameters.
 
-    def save(self, *args, **kwargs):
-        return self._fig.save(*args, **kwargs)
+        Parameters
+        ----------
+        **limits:
+            Min and max limits for each dimension to be cropped.
+        """
+        return self._fig.crop(**limits)
+
+    def save(self, filename, **kwargs):
+        """
+        Save the figure to file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, and ``.pdf``.
+        """
+        return self._fig.canvas.save(filename, **kwargs)
 
     def update(self, *args, **kwargs):
         return self._fig.update(*args, **kwargs)

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -98,7 +98,7 @@ class Canvas:
         else:
             self.fig.update_layout(yaxis={'autorange': True}, xaxis={'autorange': True})
 
-    def savefig(self, filename: str):
+    def save(self, filename: str):
         """
         Save the figure to file.
         The default directory for writing the file is the same as the
@@ -251,7 +251,7 @@ class Canvas:
         elif value is None:
             self.reset_mode()
 
-    def save_figure(self):
+    def download_figure(self):
         """
         Save the figure to a PNG file via a pop-up dialog.
         """

--- a/src/plopp/backends/plotly/figure.py
+++ b/src/plopp/backends/plotly/figure.py
@@ -42,11 +42,30 @@ class Figure(VBox):
     def graph_nodes(self):
         return self._fig.graph_nodes
 
-    def crop(self, *args, **kwargs):
-        return self._fig.crop(*args, **kwargs)
+    def crop(self, **limits):
+        """
+        Set the axes limits according to the crop parameters.
 
-    def save(self, *args, **kwargs):
-        return self._fig.save(*args, **kwargs)
+        Parameters
+        ----------
+        **limits:
+            Min and max limits for each dimension to be cropped.
+        """
+        return self._fig.crop(**limits)
+
+    def save(self, filename, **kwargs):
+        """
+        Save the figure to file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
+            ``.svg``, ``.pdf``, and ``html``.
+        """
+        return self._fig.canvas.save(filename, **kwargs)
 
     def update(self, *args, **kwargs):
         return self._fig.update(*args, **kwargs)

--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -35,6 +35,7 @@ class Canvas:
         self.outline = None
         self.axticks = None
         self.figsize = figsize
+        self.title = title
         width, height = self.figsize
 
         self.camera = p3.PerspectiveCamera(aspect=width / height)

--- a/src/plopp/backends/pythreejs/figure.py
+++ b/src/plopp/backends/pythreejs/figure.py
@@ -3,6 +3,7 @@
 
 from ...widgets import HBar, VBar, make_toolbar_canvas3d
 from ipywidgets import VBox, HBox
+import os
 
 
 class Figure(VBox):
@@ -65,6 +66,9 @@ class Figure(VBox):
         filename:
             Name of the output HTML file.
         """
+        ext = os.path.splitext(filename)[1]
+        if ext.lower() != '.html':
+            raise ValueError('File extension must be .html for saving 3d figures.')
         from ipywidgets.embed import dependency_state, embed_minimal_html
         out = HBox([self._fig.canvas.to_widget(), self.right_bar])
         # Garbage collection for embedded html output:

--- a/src/plopp/backends/pythreejs/figure.py
+++ b/src/plopp/backends/pythreejs/figure.py
@@ -53,3 +53,26 @@ class Figure(VBox):
 
     def remove(self, *args, **kwargs):
         return self._fig.remove(*args, **kwargs)
+
+    def save(self, filename):
+        """
+        Save the figure to a standalone HTML file.
+        The default directory for writing the file is the same as the
+        directory where the script or notebook is running.
+
+        Parameters
+        ----------
+        filename:
+            Name of the output HTML file.
+        """
+        from ipywidgets.embed import dependency_state, embed_minimal_html
+        out = HBox([self._fig.canvas.to_widget(), self.right_bar])
+        # Garbage collection for embedded html output:
+        # https://github.com/jupyter-widgets/pythreejs/issues/217
+        state = dependency_state(out)
+        # convert and write to file
+        embed_minimal_html(
+            filename,
+            out,
+            title=self._fig.canvas.title if self._fig.canvas.title else 'figure3d',
+            state=state)

--- a/src/plopp/graphics/figimage.py
+++ b/src/plopp/graphics/figimage.py
@@ -172,17 +172,3 @@ class FigImage(BaseFig):
             Min and max limits for each dimension to be cropped.
         """
         self.canvas.crop(**{xy: limits[self.dims[xy]] for xy in 'xy'})
-
-    def save(self, filename: str, **kwargs):
-        """
-        Save the figure to file.
-        The default directory for writing the file is the same as the
-        directory where the script or notebook is running.
-
-        Parameters
-        ----------
-        filename:
-            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
-            ``.svg``, and ``.pdf``.
-        """
-        self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/graphics/figline.py
+++ b/src/plopp/graphics/figline.py
@@ -155,17 +155,3 @@ class FigLine(BaseFig):
             Min and max limits for each dimension to be cropped.
         """
         self.canvas.crop(x=limits[self.dims['x']])
-
-    def save(self, filename: str, **kwargs):
-        """
-        Save the figure to file.
-        The default directory for writing the file is the same as the
-        directory where the script or notebook is running.
-
-        Parameters
-        ----------
-        filename:
-            Name of the output file. Possible file extensions are ``.jpg``, ``.png``,
-            ``.svg``, and ``.pdf``.
-        """
-        self.canvas.savefig(filename=filename, **kwargs)

--- a/src/plopp/widgets/toolbar.py
+++ b/src/plopp/widgets/toolbar.py
@@ -66,7 +66,7 @@ def make_toolbar_canvas2d(canvas: Any,
     if colormapper is not None:
         tool_list['lognorm'] = tools.LogNormTool(colormapper.toggle_norm,
                                                  value=colormapper.norm == 'log')
-    tool_list['save'] = tools.SaveTool(canvas.save_figure)
+    tool_list['save'] = tools.SaveTool(canvas.download_figure)
     return Toolbar(tools=tool_list)
 
 

--- a/tests/backends/matplotlib/mpl_canvas_test.py
+++ b/tests/backends/matplotlib/mpl_canvas_test.py
@@ -95,3 +95,9 @@ def test_save_to_disk(ext):
         fname = os.path.join(path, f'plopp_fig.{ext}')
         canvas.save(filename=fname)
         assert os.path.isfile(fname)
+
+
+def test_save_to_disk_with_bad_extension_raises():
+    canvas = Canvas()
+    with pytest.raises(ValueError):
+        canvas.save(filename='plopp_fig.txt')

--- a/tests/backends/matplotlib/mpl_canvas_test.py
+++ b/tests/backends/matplotlib/mpl_canvas_test.py
@@ -93,5 +93,5 @@ def test_save_to_disk(ext):
     canvas = Canvas()
     with tempfile.TemporaryDirectory() as path:
         fname = os.path.join(path, f'plopp_fig.{ext}')
-        canvas.savefig(filename=fname)
+        canvas.save(filename=fname)
         assert os.path.isfile(fname)

--- a/tests/backends/plotly/plotly_canvas_test.py
+++ b/tests/backends/plotly/plotly_canvas_test.py
@@ -85,5 +85,5 @@ def test_save_to_disk(ext):
     canvas = Canvas()
     with tempfile.TemporaryDirectory() as path:
         fname = os.path.join(path, f'plopp_fig.{ext}')
-        canvas.savefig(filename=fname)
+        canvas.save(filename=fname)
         assert os.path.isfile(fname)

--- a/tests/backends/plotly/plotly_canvas_test.py
+++ b/tests/backends/plotly/plotly_canvas_test.py
@@ -87,3 +87,9 @@ def test_save_to_disk(ext):
         fname = os.path.join(path, f'plopp_fig.{ext}')
         canvas.save(filename=fname)
         assert os.path.isfile(fname)
+
+
+def test_save_to_disk_with_bad_extension_raises():
+    canvas = Canvas()
+    with pytest.raises(ValueError):
+        canvas.save(filename='plopp_fig.txt')

--- a/tests/backends/pythreejs/pythreejs_figure_test.py
+++ b/tests/backends/pythreejs/pythreejs_figure_test.py
@@ -5,6 +5,8 @@ from plopp import input_node
 from plopp.data.testing import scatter
 from plopp.backends.pythreejs.figure import Figure
 from plopp.graphics.figscatter3d import FigScatter3d
+import tempfile
+import os
 
 
 def test_log_norm_3d_toolbar_button():
@@ -27,6 +29,6 @@ def test_save_to_html():
                  z='z',
                  norm='log')
     with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, f'plopp_fig.html')
+        fname = os.path.join(path, 'plopp_fig.html')
         fig.save(filename=fname)
         assert os.path.isfile(fname)

--- a/tests/backends/pythreejs/pythreejs_figure_test.py
+++ b/tests/backends/pythreejs/pythreejs_figure_test.py
@@ -16,3 +16,17 @@ def test_log_norm_3d_toolbar_button():
                  z='z',
                  norm='log')
     assert fig.toolbar['lognorm'].value
+
+
+def test_save_to_html():
+    da = scatter()
+    fig = Figure(input_node(da),
+                 FigConstructor=FigScatter3d,
+                 x='x',
+                 y='y',
+                 z='z',
+                 norm='log')
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, f'plopp_fig.html')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)

--- a/tests/backends/pythreejs/pythreejs_figure_test.py
+++ b/tests/backends/pythreejs/pythreejs_figure_test.py
@@ -5,6 +5,7 @@ from plopp import input_node
 from plopp.data.testing import scatter
 from plopp.backends.pythreejs.figure import Figure
 from plopp.graphics.figscatter3d import FigScatter3d
+import pytest
 import tempfile
 import os
 
@@ -29,6 +30,18 @@ def test_save_to_html():
                  z='z',
                  norm='log')
     with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, 'plopp_fig.html')
+        fname = os.path.join(path, 'plopp_fig3d.html')
         fig.save(filename=fname)
         assert os.path.isfile(fname)
+
+
+def test_save_to_html_with_bad_extension_raises():
+    da = scatter()
+    fig = Figure(input_node(da),
+                 FigConstructor=FigScatter3d,
+                 x='x',
+                 y='y',
+                 z='z',
+                 norm='log')
+    with pytest.raises(ValueError, match=r'File extension must be \.html'):
+        fig.save(filename='plopp_fig3d.png')

--- a/tests/functions/plot_test.py
+++ b/tests/functions/plot_test.py
@@ -6,6 +6,8 @@ import plopp as pp
 from plopp.data.testing import data_array, dataset
 import pytest
 import scipp as sc
+import tempfile
+import os
 
 
 def test_plot_ndarray():
@@ -78,7 +80,7 @@ def test_plot_2d_coord():
 
 
 def test_plot_2d_coord_with_mask():
-    da = pp.data.data_array(ndim=2, ragged=True)
+    da = data_array(ndim=2, ragged=True)
     da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')
     pp.plot(da)
 
@@ -241,3 +243,30 @@ def test_use_non_dimension_coords_dataset():
     p = pp.plot(ds, coords=['xx2'])
     assert p._fig.dims['x'] == 'xx2'
     assert p.canvas._xmax > 6.6 * ds.coords['xx'].max().value
+
+
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk_1d(ext):
+    da = data_array(ndim=1)
+    fig = pp.plot(da)
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, f'plopp_fig1d.{ext}')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)
+
+
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk_2d(ext):
+    da = data_array(ndim=2)
+    fig = pp.plot(da)
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, f'plopp_fig2d.{ext}')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)
+
+
+def test_save_to_disk_with_bad_extension_raises():
+    da = data_array(ndim=2)
+    fig = pp.plot(da)
+    with pytest.raises(ValueError):
+        fig.save(filename='plopp_fig2d.txt')

--- a/tests/graphics/figimage_test.py
+++ b/tests/graphics/figimage_test.py
@@ -6,8 +6,6 @@ from plopp.graphics.figimage import FigImage
 from plopp import input_node
 import scipp as sc
 import pytest
-import tempfile
-import os
 
 
 def test_empty():
@@ -92,23 +90,6 @@ def test_crop_no_variable():
                    })
     assert fig.canvas.xrange == (xmin, xmax)
     assert fig.canvas.yrange == (ymin, ymax)
-
-
-@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
-def test_save_to_disk(ext):
-    da = data_array(ndim=2)
-    fig = FigImage(input_node(da))
-    with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, f'plopp_fig2d.{ext}')
-        fig.save(filename=fname)
-        assert os.path.isfile(fname)
-
-
-def test_save_to_disk_with_bad_extension_raises():
-    da = data_array(ndim=2)
-    fig = FigImage(input_node(da))
-    with pytest.raises(ValueError):
-        fig.save(filename='plopp_fig2d.txt')
 
 
 def test_raises_for_new_data_with_incompatible_dimension():

--- a/tests/graphics/figline_test.py
+++ b/tests/graphics/figline_test.py
@@ -7,8 +7,6 @@ from plopp import input_node
 import numpy as np
 import scipp as sc
 import pytest
-import tempfile
-import os
 
 
 def test_empty():
@@ -144,16 +142,6 @@ def test_vmin_vmax_no_variable():
     da = data_array(ndim=1)
     fig = FigLine(input_node(da), vmin=-0.5, vmax=0.68)
     assert np.allclose(fig.canvas.yrange, [-0.5, 0.68])
-
-
-@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
-def test_save_to_disk(ext):
-    da = data_array(ndim=1)
-    fig = FigLine(input_node(da))
-    with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, f'plopp_fig1d.{ext}')
-        fig.save(filename=fname)
-        assert os.path.isfile(fname)
 
 
 def test_raises_for_new_data_with_incompatible_dimension():


### PR DESCRIPTION
Adds the `.save` method to 3d figures so they can be saved as a standalone html file.

Depends on #139 