### PR TITLE
Resize button for 3d plots

### DIFF
--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -190,3 +190,11 @@ class Canvas:
     def title(self, text: str):
         self._title_text = text
         self._title = self._make_title()
+
+    def set_resolution(self, resolution):
+        if resolution is None:
+            return
+        width, height = resolution
+        self.renderer.width = width
+        self.renderer.height = height
+        self.camera.aspect = width / height

--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -37,7 +37,7 @@ class Canvas:
         self.zunit = None
         self.outline = None
         self.axticks = None
-        self.figsize = figsize
+        self.figsize = np.asarray(figsize)
         self._title_text = title
         self._title = self._make_title()
         width, height = self.figsize
@@ -191,10 +191,15 @@ class Canvas:
         self._title_text = text
         self._title = self._make_title()
 
-    def set_resolution(self, resolution):
-        if resolution is None:
-            return
-        width, height = resolution
-        self.renderer.width = width
-        self.renderer.height = height
-        self.camera.aspect = width / height
+    def bigger(self):
+        self.figsize = (self.figsize * 1.2).astype(int)
+        self._update_size()
+
+    def smaller(self):
+        self.figsize = (self.figsize / 1.2).astype(int)
+        self._update_size()
+
+    def _update_size(self):
+        self.renderer.width = self.figsize[0]
+        self.renderer.height = self.figsize[1]
+        self.camera.aspect = self.figsize[0] / self.figsize[1]

--- a/src/plopp/widgets/toolbar.py
+++ b/src/plopp/widgets/toolbar.py
@@ -23,7 +23,11 @@ class Toolbar(VBox):
         self.tools = {}
         if tools is not None:
             for key, tool in tools.items():
-                setattr(self, key, tool.callback)
+                if isinstance(tool.callback, dict):
+                    for name, cb in tool.callback.items():
+                        setattr(self, name, cb)
+                else:
+                    setattr(self, key, tool.callback)
                 self.tools[key] = tool
 
         super().__init__()
@@ -111,12 +115,11 @@ def make_toolbar_canvas3d(canvas: Any,
         tools.OutlineTool(canvas.toggle_outline),
         'axes':
         tools.AxesTool(canvas.toggle_axes3d),
-        'settings':
-        tools.DropdownTool(canvas.set_resolution,
-                           options=[('\u2699', None), ('360p', [480, 360]),
-                                    ('480p', [640, 480]), ('720p', [1280, 720]),
-                                    ('1080p', [1920, 1080]), ('4K', [3840, 2160])],
-                           style={'font_weight': 'bold'},
-                           tooltip='Select resolution')
+        'size':
+        tools.PlusMinusTool({
+            'plus': canvas.bigger,
+            'minus': canvas.smaller
+        },
+                            tooltip='Canvas size')
     })
     return Toolbar(tools=tool_list)

--- a/src/plopp/widgets/toolbar.py
+++ b/src/plopp/widgets/toolbar.py
@@ -116,10 +116,13 @@ def make_toolbar_canvas3d(canvas: Any,
         'axes':
         tools.AxesTool(canvas.toggle_axes3d),
         'size':
-        tools.PlusMinusTool({
-            'plus': canvas.bigger,
-            'minus': canvas.smaller
+        tools.PlusMinusTool(plus={
+            'callback': canvas.bigger,
+            'tooltip': 'Increase canvas size'
         },
-                            tooltip='Canvas size')
+                            minus={
+                                'callback': canvas.smaller,
+                                'tooltip': 'Decrease canvas size'
+                            })
     })
     return Toolbar(tools=tool_list)

--- a/src/plopp/widgets/toolbar.py
+++ b/src/plopp/widgets/toolbar.py
@@ -107,7 +107,16 @@ def make_toolbar_canvas3d(canvas: Any,
         tool_list['lognorm'] = tools.LogNormTool(colormapper.toggle_norm,
                                                  value=colormapper.norm == 'log')
     tool_list.update({
-        'box': tools.OutlineTool(canvas.toggle_outline),
-        'axes': tools.AxesTool(canvas.toggle_axes3d)
+        'box':
+        tools.OutlineTool(canvas.toggle_outline),
+        'axes':
+        tools.AxesTool(canvas.toggle_axes3d),
+        'settings':
+        tools.DropdownTool(canvas.set_resolution,
+                           options=[('\u2699', None), ('360p', [480, 360]),
+                                    ('480p', [640, 480]), ('720p', [1280, 720]),
+                                    ('1080p', [1920, 1080]), ('4K', [3840, 2160])],
+                           style={'font_weight': 'bold'},
+                           tooltip='Select resolution')
     })
     return Toolbar(tools=tool_list)

--- a/src/plopp/widgets/tools.py
+++ b/src/plopp/widgets/tools.py
@@ -52,6 +52,28 @@ class ToggleTool(ipw.ToggleButton):
         self.callback()
 
 
+class DropdownTool(ipw.Dropdown):
+    """
+    Create a dropdown menu with a callback that is called when the selected value is
+    changed.
+
+    Parameters
+    ----------
+    callback:
+        The function that will be called when the selected value is changed.
+    **kwargs:
+        All other kwargs are forwarded to ipywidgets.Dropdown.
+    """
+
+    def __init__(self, callback: Callable, **kwargs):
+        super().__init__(**{**BUTTON_LAYOUT, **kwargs})
+        self.callback = callback
+        self.observe(self, names='value')
+
+    def __call__(self, *ignored):
+        self.callback(self.value)
+
+
 class MultiToggleTool(ipw.VBox):
     """
     Create toggle buttons with a callback that is called when one of the buttons is

--- a/src/plopp/widgets/tools.py
+++ b/src/plopp/widgets/tools.py
@@ -52,26 +52,47 @@ class ToggleTool(ipw.ToggleButton):
         self.callback()
 
 
-class DropdownTool(ipw.Dropdown):
-    """
-    Create a dropdown menu with a callback that is called when the selected value is
-    changed.
+# class DropdownTool(ipw.Dropdown):
+#     """
+#     Create a dropdown menu with a callback that is called when the selected value is
+#     changed.
 
-    Parameters
-    ----------
-    callback:
-        The function that will be called when the selected value is changed.
-    **kwargs:
-        All other kwargs are forwarded to ipywidgets.Dropdown.
-    """
+#     Parameters
+#     ----------
+#     callback:
+#         The function that will be called when the selected value is changed.
+#     **kwargs:
+#         All other kwargs are forwarded to ipywidgets.Dropdown.
+#     """
 
-    def __init__(self, callback: Callable, **kwargs):
-        super().__init__(**{**BUTTON_LAYOUT, **kwargs})
+#     def __init__(self, callback: Callable, **kwargs):
+#         super().__init__(**{**BUTTON_LAYOUT, **kwargs})
+#         self.callback = callback
+#         self.observe(self, names='value')
+
+#     def __call__(self, *ignored):
+#         self.callback(self.value)
+
+
+class PlusMinusTool(ipw.HBox):
+
+    def __init__(self, callback, **kwargs):
+        layout = {'width': '16px', 'padding': '0px'}
+        self._plus = ipw.Button(icon='plus', layout=layout, **kwargs)
+        self._minus = ipw.Button(icon='minus', layout=layout, **kwargs)
+
         self.callback = callback
-        self.observe(self, names='value')
+        # self._callback_plus = callbacks['plus']
+        # self._callback_minus = callbacks['minus']
+        self._plus.on_click(self.plus)
+        self._minus.on_click(self.minus)
+        super().__init__([self._plus, self._minus])
 
-    def __call__(self, *ignored):
-        self.callback(self.value)
+    def plus(self, *ignored):
+        self.callback['plus']()
+
+    def minus(self, *ignored):
+        self.callback['minus']()
 
 
 class MultiToggleTool(ipw.VBox):

--- a/src/plopp/widgets/tools.py
+++ b/src/plopp/widgets/tools.py
@@ -52,47 +52,31 @@ class ToggleTool(ipw.ToggleButton):
         self.callback()
 
 
-# class DropdownTool(ipw.Dropdown):
-#     """
-#     Create a dropdown menu with a callback that is called when the selected value is
-#     changed.
-
-#     Parameters
-#     ----------
-#     callback:
-#         The function that will be called when the selected value is changed.
-#     **kwargs:
-#         All other kwargs are forwarded to ipywidgets.Dropdown.
-#     """
-
-#     def __init__(self, callback: Callable, **kwargs):
-#         super().__init__(**{**BUTTON_LAYOUT, **kwargs})
-#         self.callback = callback
-#         self.observe(self, names='value')
-
-#     def __call__(self, *ignored):
-#         self.callback(self.value)
-
-
 class PlusMinusTool(ipw.HBox):
 
-    def __init__(self, callback, **kwargs):
+    def __init__(self, plus, minus):
         layout = {'width': '16px', 'padding': '0px'}
-        self._plus = ipw.Button(icon='plus', layout=layout, **kwargs)
-        self._minus = ipw.Button(icon='minus', layout=layout, **kwargs)
-
-        self.callback = callback
-        # self._callback_plus = callbacks['plus']
-        # self._callback_minus = callbacks['minus']
+        self.callback = {'plus': plus.pop('callback'), 'minus': minus.pop('callback')}
+        self._plus = ipw.Button(icon='plus', **{**{'layout': layout}, **plus})
+        self._minus = ipw.Button(icon='minus', **{**{'layout': layout}, **minus})
         self._plus.on_click(self.plus)
         self._minus.on_click(self.minus)
-        super().__init__([self._plus, self._minus])
+        super().__init__([self._minus, self._plus])
 
     def plus(self, *ignored):
         self.callback['plus']()
 
     def minus(self, *ignored):
         self.callback['minus']()
+
+    @property
+    def disabled(self):
+        return self._plus.disabled
+
+    @disabled.setter
+    def disabled(self, value):
+        self._plus.disabled = value
+        self._minus.disabled = value
 
 
 class MultiToggleTool(ipw.VBox):

--- a/tests/widgets/cut3d_test.py
+++ b/tests/widgets/cut3d_test.py
@@ -47,13 +47,13 @@ def test_cut_thickness():
     tri.cut_x.button.value = True
     pts = list(fig.artists.values())[-1]
     npoints = pts.geometry.attributes['position'].array.shape[0]
-    tri.cut_x.button_plus.click()
+    tri.cut_x.plus_minus.plus()
     new_pts = list(fig.artists.values())[-1]
     assert npoints < new_pts.geometry.attributes['position'].array.shape[0]
-    tri.cut_x.button_minus.click()
+    tri.cut_x.plus_minus.minus()
     new_pts = list(fig.artists.values())[-1]
     assert npoints == new_pts.geometry.attributes['position'].array.shape[0]
-    tri.cut_x.button_minus.click()
+    tri.cut_x.plus_minus.minus()
     new_pts = list(fig.artists.values())[-1]
     assert npoints > new_pts.geometry.attributes['position'].array.shape[0]
 


### PR DESCRIPTION
This adds a `+/-` button in the toolbar of 3d plots which allows for easy resizing of the canvas (instead of setting `figsize` in the arguments).

To test:
```Py
import plopp as pp
da = pp.data.scatter()
pp.scatter3d(da)
```
![Screenshot at 2023-02-27 11-51-58](https://user-images.githubusercontent.com/39047984/221544915-9b799a1c-a2bb-4fe6-96ca-d7c236d8d5b8.png)
