### PR TITLE
Fix colormapper normalize limits in the case where data vmin == 1.0

### DIFF
--- a/tests/graphics/colormapper_test.py
+++ b/tests/graphics/colormapper_test.py
@@ -71,6 +71,20 @@ def test_rescale_limits_do_not_shrink():
     assert mapper.vmax == da.max().value
 
 
+def test_correct_normalizer_limits():
+    da = sc.DataArray(data=sc.array(dims=['y', 'x'], values=[[1, 2], [3, 4]]))
+    mapper = ColorMapper()
+    mapper.update(data=da, key=None)
+    assert mapper.vmin == da.min().value
+    assert mapper.vmax == da.max().value
+    # The normalizer initially has limits [0, 1].
+    # In Matplotlib, if we set the normalizer vmin value (1) equal to the current vmax,
+    # it will silently set it to something smaller, e.g. 0.9.
+    # Our implementation needs to work around this.
+    assert mapper.normalizer.vmin == da.min().value
+    assert mapper.normalizer.vmax == da.max().value
+
+
 def test_vmin_vmax():
     da = data_array(ndim=2, unit='K')
     vmin = sc.scalar(-0.1, unit='K')


### PR DESCRIPTION
```Py
import numpy as np
import scipp as sc

a = np.array([[1, 2], [3, 4]])
pp.plot(a)
```
would give
![Screenshot at 2023-03-02 13-43-08](https://user-images.githubusercontent.com/39047984/222432060-6a41d76f-dd6d-4366-9486-f33c49629c56.png)

Note that the lower bound on the colorbar is 0.9, not 1.0 (which it should be).
This is because we were not correctly catching the case where `vmin == normalizer.vmax`, we were only checking for greater than.
So matplotlib was silently changing it to 0.9 before updating the vmax.