### PR TITLE
Better error message when trying to plot unsupported data type

### DIFF
--- a/src/plopp/functions/common.py
+++ b/src/plopp/functions/common.py
@@ -21,7 +21,8 @@ def require_interactive_backend(func: str):
                            "notebook.")
 
 
-def _to_data_array(obj: Union[np.ndarray, sc.Variable, sc.DataArray]):
+def _to_data_array(
+        obj: Union[list, np.ndarray, sc.Variable, sc.DataArray]) -> sc.DataArray:
     """
     Convert an input to a DataArray, potentially adding fake coordinates if they are
     missing.
@@ -34,6 +35,8 @@ def _to_data_array(obj: Union[np.ndarray, sc.Variable, sc.DataArray]):
         out = sc.Variable(dims=dims, values=out)
     if isinstance(out, sc.Variable):
         out = sc.DataArray(data=out)
+    if not isinstance(out, sc.DataArray):
+        raise ValueError(f"Cannot convert input of type {type(obj)} to a DataArray.")
     out = out.copy(deep=False)
     for dim, size in out.sizes.items():
         if dim not in out.meta:

--- a/tests/functions/plot_test.py
+++ b/tests/functions/plot_test.py
@@ -236,6 +236,16 @@ def test_raises_ValueError_when_given_binned_data():
         pp.plot(da)
 
 
+def test_raises_ValueError_when_given_unsupported_data_type():
+    a = data_array(ndim=1)
+    b = a * 2.0
+    c = a * 3.0
+    d = a * 4.0
+    nested_dict = {'group1': {'a': a, 'b': b}, 'group2': {'c': c, 'd': d}}
+    with pytest.raises(ValueError, match='Cannot convert input of type'):
+        pp.plot(nested_dict)
+
+
 def test_use_non_dimension_coords():
     da = data_array(ndim=2, binedges=True)
     da.coords['xx2'] = 7.5 * da.coords['xx']


### PR DESCRIPTION
Currently, when trying to plot a dict that contains other dicts, e.g.
```Py
import plopp as pp

a = pp.data.data1d()
b = a * 2.0
c = a * 3.0
d = a * 4.0

data = {'group1': {'a': a, 'b': b}, 'group2': {'c': c, 'd': d}}
pp.plot(data)
```
we get the confusing error
```
File ~/code/plopp/jupyter/plopp/functions/common.py:37, in _to_data_array(obj)
     35 if isinstance(out, sc.Variable):
     36     out = sc.DataArray(data=out)
---> 37 out = out.copy(deep=False)
     38 for dim, size in out.sizes.items():
     39     if dim not in out.meta:

TypeError: dict.copy() takes no keyword arguments
```

This changes the error message to `Cannot convert input of type <class 'dict'> to a DataArray.` (and also catches other things than just dicts).