### PR TITLE
Better formatting for slider values

### DIFF
--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -181,7 +181,11 @@ def coord_element_to_string(x: sc.Variable) -> str:
     x:
         The input variable (of length 1 or 2).
     """
-    out = value_to_string(x.values)
+    vals = x.values
+    if vals.shape:
+        out = ':'.join([value_to_string(v) for v in vals])
+    else:
+        out = value_to_string(float(vals))
     if x.unit is not None:
         out += f" [{x.unit}]"
     return out


### PR DESCRIPTION
Fix slider label text that was not being parsed by `value_to_string` because it was a 1d numpy array instead of a float.

Before:
![Screenshot at 2023-03-23 15-17-11](https://user-images.githubusercontent.com/39047984/227232308-cfabe5fd-2c99-4ddb-bf4d-dd47c5a7f900.png)

After:
![Screenshot at 2023-03-23 15-13-20](https://user-images.githubusercontent.com/39047984/227232343-1484ca29-e1ee-47ed-befa-7b0d236d923e.png)
