### PR TITLE
Pin conda version for anaconda upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.10
       - run: conda install -c conda-forge --yes anaconda-client
       - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-*/*/*.tar.bz2)
       - uses: actions/setup-python@v3


### PR DESCRIPTION
Python 3.11 in this step broke the ScippNexus release build. Have to assume the same would have happened for Scipp.