### PR TITLE
Change the behaviour of autoscaling limits

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -141,10 +141,6 @@ class Canvas:
         draw:
             Make a draw call to the figure if ``True``.
         """
-        xmin = np.inf
-        xmax = np.NINF
-        ymin = np.inf
-        ymax = np.NINF
         if self.ax.lines:
             self.ax.relim()
             self.ax.autoscale()

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -150,10 +150,6 @@ class Canvas:
             self.ax.autoscale()
             xmin, xmax = self.ax.get_xlim()
             ymin, ymax = self.ax.get_ylim()
-            # self._xmin = min(self._xmin, xmin)
-            # self._xmax = max(self._xmax, xmax)
-            # self._ymin = min(self._ymin, ymin)
-            # self._ymax = max(self._ymax, ymax)
         else:
             xmin = np.inf
             xmax = np.NINF

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -205,8 +205,8 @@ class Line:
         new_values = self._make_data()
 
         self._line.set_data(new_values['values']['x'], new_values['values']['y'])
+        self._mask.set_data(new_values['mask']['x'], new_values['mask']['y'])
         if new_values['mask']['visible']:
-            self._mask.set_data(new_values['mask']['x'], new_values['mask']['y'])
             self._mask.set_visible(True)
         else:
             self._mask.set_visible(False)

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -28,7 +28,7 @@ def find_limits(
     return (scalar(finite_min, unit=x.unit), scalar(finite_max, unit=x.unit))
 
 
-def fix_empty_range(lims: Tuple[Variable, ...]) -> Tuple[Variable, ...]:
+def fix_empty_range(lims: Tuple[Variable, Variable]) -> Tuple[Variable, Variable]:
     """
     Range correction in case xmin == xmax
     """

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -109,7 +109,7 @@ def maybe_variable_to_number(
     if hasattr(x, 'unit'):
         if unit is not None:
             x = x.to(unit=unit)
-        x = x.values
+        x = x.values if x.dims else x.value
     return x
 
 

--- a/src/plopp/functions/plot.py
+++ b/src/plopp/functions/plot.py
@@ -29,6 +29,7 @@ def plot(
     title: Optional[str] = None,
     vmin: Optional[Union[Variable, int, float]] = None,
     vmax: Optional[Union[Variable, int, float]] = None,
+    autoscale: Literal['auto', 'grow'] = 'auto',
     **kwargs,
 ):
     """Plot a Scipp object.
@@ -73,6 +74,10 @@ def plot(
     vmax:
         Upper bound for data to be displayed (y-axis for 1d plots, colorscale for
         2d plots).
+    autoscale:
+        The behavior of the axis (1d plots) or the color range limits (2d plots).
+        If ``auto``, the limits automatically adjusts every time the data changes.
+        If ``grow``, the limits are allowed to grow with time but they do not shrink.
     **kwargs:
         All other kwargs are directly forwarded to Matplotlib, the underlying plotting
         library. The underlying functions called are the following:
@@ -95,6 +100,7 @@ def plot(
         'title': title,
         'vmin': vmin,
         'vmax': vmax,
+        'autoscale': autoscale,
         'figsize': figsize,
         **kwargs,
     }

--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -35,6 +35,16 @@ class Slicer:
         be a list of dims. If no dims are provided, the last dim will be kept in the
         case of a 2-dimensional input, while the last two dims will be kept in the case
         of higher dimensional inputs.
+    autoscale:
+        The behavior of the y-axis (1d plots) and color range (2d plots) limits.
+        If ``auto``, the limits automatically adjusts every time the data changes.
+        If ``grow``, the limits are allowed to grow with time but they do not shrink.
+        If ``fixed``, the limits are fixed to the full data range and do not change
+        with time.
+    vmin:
+        The minimum value of the y-axis (1d plots) or color range (2d plots).
+    vmax:
+        The maximum value of the y-axis (1d plots) or color range (2d plots).
     crop:
         Set the axis limits. Limits should be given as a dict with one entry per
         dimension to be cropped.
@@ -115,6 +125,9 @@ def slicer(
     obj: Union[VariableLike, ndarray, Dict[str, Union[VariableLike, ndarray]]],
     keep: List[str] = None,
     *,
+    autoscale: Literal['auto', 'grow', 'fixed'] = 'auto',
+    vmin: Union[VariableLike, int, float] = None,
+    vmax: Union[VariableLike, int, float] = None,
     crop: Dict[str, Dict[str, sc.Variable]] = None,
     **kwargs,
 ):
@@ -131,6 +144,16 @@ def slicer(
         be a list of dims. If no dims are provided, the last dim will be kept in the
         case of a 2-dimensional input, while the last two dims will be kept in the case
         of higher dimensional inputs.
+    autoscale:
+        The behavior of the y-axis (1d plots) and color range (2d plots) limits.
+        If ``auto``, the limits automatically adjusts every time the data changes.
+        If ``grow``, the limits are allowed to grow with time but they do not shrink.
+        If ``fixed``, the limits are fixed to the full data range and do not change
+        with time.
+    vmin:
+        The minimum value of the y-axis (1d plots) or color range (2d plots).
+    vmax:
+        The maximum value of the y-axis (1d plots) or color range (2d plots).
     crop:
         Set the axis limits. Limits should be given as a dict with one entry per
         dimension to be cropped. Each entry should be a nested dict containing scalar
@@ -145,7 +168,15 @@ def slicer(
         A :class:`Box` which will contain a :class:`Figure` and slider widgets.
     """
     require_interactive_backend('slicer')
-    sl = Slicer(obj=obj, keep=keep, crop=crop, **kwargs)
+    sl = Slicer(
+        obj=obj,
+        keep=keep,
+        autoscale=autoscale,
+        vmin=vmin,
+        vmax=vmax,
+        crop=crop,
+        **kwargs,
+    )
     from ..widgets import Box
 
     return Box([sl.figure, sl.slider])

--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -3,6 +3,7 @@
 
 from functools import reduce
 from typing import Dict, List, Literal, Union
+import warnings
 
 import scipp as sc
 from numpy import ndarray
@@ -83,13 +84,16 @@ class Slicer:
             )
 
         if autoscale == 'fixed':
-            if ('vmin' in kwargs) or ('vmax' in kwargs):
-                raise ValueError(
-                    'Slicer plot: when autoscale is set to "fixed", vmin and/or vmax '
-                    'cannot be specified.'
+            if None not in (vmin, vmax):
+                warnings.warn(
+                    'Slicer plot: autoscale is set to "fixed", but vmin and vmax '
+                    'are also specified. They will override the autoscale setting.',
+                    RuntimeWarning,
                 )
-            vmin = reduce(min, [da.data.min() for da in ds.values()])
-            vmax = reduce(max, [da.data.max() for da in ds.values()])
+            if vmin is None:
+                vmin = reduce(min, [da.data.min() for da in ds.values()])
+            if vmax is None:
+                vmax = reduce(max, [da.data.max() for da in ds.values()])
             autoscale = 'auto'  # Change back to something the figure understands
 
         from ..widgets import SliceWidget, slice_dims

--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+import warnings
 from functools import reduce
 from typing import Dict, List, Literal, Union
-import warnings
 
 import scipp as sc
 from numpy import ndarray

--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -78,8 +78,8 @@ class Slicer:
                     'Slicer plot: when autoscale is set to "fixed", vmin and/or vmax '
                     'cannot be specified.'
                 )
-            vmin = reduce(min, [da.min() for da in ds.values()])
-            vmax = reduce(max, [da.max() for da in ds.values()])
+            vmin = reduce(min, [da.data.min() for da in ds.values()])
+            vmax = reduce(max, [da.data.max() for da in ds.values()])
             autoscale = 'auto'  # Change back to something the figure understands
 
         from ..widgets import SliceWidget, slice_dims

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from copy import copy
 from collections.abc import Iterable
+from copy import copy
 from functools import reduce
 from typing import Any, Literal, Optional, Tuple, Union
 

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -17,8 +17,6 @@ from ..backends.matplotlib.utils import fig_to_bytes, silent_mpl_figure
 from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import maybe_variable_to_number, merge_masks
 
-NO_UNIT = object()
-
 
 def _get_cmap(name: str, nan_color: str = None) -> Colormap:
     """
@@ -120,7 +118,8 @@ class ColorMapper:
         # raised when making the colorbar before any call to update is made.
         self.normalizer = _get_normalizer(self.norm)
         self.colorbar = None
-        self.unit = NO_UNIT
+        self.unit = None
+
         self.name = None
         self.changed = False
         self.artists = {}
@@ -241,8 +240,9 @@ class ColorMapper:
         key:
             The id of the node that provided this data.
         """
-        if self.unit is NO_UNIT:
-            self.unit = data.unit
+        if self.name is None:
+            self.name = data.name
+            # If name is None, this is the first time update is called
             if self.user_vmin is not None:
                 self.user_vmin = maybe_variable_to_number(
                     self.user_vmin, unit=self.unit
@@ -251,14 +251,6 @@ class ColorMapper:
                 self.user_vmax = maybe_variable_to_number(
                     self.user_vmax, unit=self.unit
                 )
-        elif data.unit != self.unit:
-            raise ValueError(
-                f'Incompatible unit: colormapper has unit {self.unit}, '
-                f'new data has unit {data.unit}.'
-            )
-
-        if self.name is None:
-            self.name = data.name
         elif data.name != self.name:
             self.name = ''
         if self.cax is not None:

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -179,12 +179,16 @@ class ColorMapper:
         vmin, vmax = fix_empty_range(find_limits(data, scale=self.norm))
         if self.user_vmin is not None:
             self.vmin = maybe_variable_to_number(self.user_vmin, unit=self.unit)
-        elif vmin.value < self.vmin:
+        else:
             self.vmin = vmin.value
+        # elif vmin.value < self.vmin:
+        #     self.vmin = vmin.value
         if self.user_vmax is not None:
             self.vmax = maybe_variable_to_number(self.user_vmax, unit=self.unit)
-        elif vmax.value > self.vmax:
+        else:
             self.vmax = vmax.value
+        # elif vmax.value > self.vmax:
+        #     self.vmax = vmax.value
 
     def _set_artists_colors(self, key: str = None):
         """
@@ -246,13 +250,13 @@ class ColorMapper:
                 text += f'{" " if self.name else ""}[{self.unit}]'
             self.cax.set_ylabel(text)
 
-        old_bounds = np.array([self.vmin, self.vmax])
+        # old_bounds = np.array([self.vmin, self.vmax])
         self.autoscale(data=data)
         self._set_normalizer_limits()
 
-        if not np.allclose(old_bounds, np.array([self.vmin, self.vmax])):
-            self._set_artists_colors(key=key)
-            self._update_colorbar_widget()
+        # if not np.allclose(old_bounds, np.array([self.vmin, self.vmax])):
+        self._set_artists_colors(key=key)
+        self._update_colorbar_widget()
 
     def toggle_norm(self):
         """

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from copy import copy
+from collections.abc import Iterable
 from functools import reduce
 from typing import Any, Literal, Optional, Tuple, Union
 
@@ -133,28 +134,10 @@ class ColorMapper:
             self.colorbar = ColorbarBase(self.cax, cmap=self.cmap, norm=self.normalizer)
             self.cax.yaxis.set_label_coords(-0.9, 0.5)
 
-    def __setitem__(self, key, data):
-        if key not in self.artists:
-            if self.unit is None:
-                self.unit = data.unit
-            elif data.unit != self.unit:
-                raise ValueError(
-                    f'Incompatible unit: colormapper has unit {self.unit}, '
-                    f'new data has unit {data.unit}.'
-                )
+    def __setitem__(self, key: str, artist: Any):
+        self.artists[key] = artist
 
-            if self.name is None:
-                self.name = data.name
-            elif data.name != self.name:
-                self.name = ''
-            if self.cax is not None:
-                text = self.name
-                if self.unit is not None:
-                    text += f'{" " if self.name else ""}[{self.unit}]'
-                self.cax.set_ylabel(text)
-        self.artists[key] = data
-
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         return self.artists[key]
 
     def to_widget(self):
@@ -191,17 +174,13 @@ class ColorMapper:
 
     def autoscale(self):
         """
-        Re-compute the min and max range of values, given new values.
-        The current range can grow but not shrink.
-
-        Parameters
-        ----------
-        data:
-            The data array containing the values to update the current range.
+        Re-compute the global min and max range of values by iterating over all the
+        artists. If autoscale is set to ``'auto'``, the limits adjust to he current
+        range. If it is set to ``'grow'``, limits can grow but not shrink.
         """
         limits = [
-            fix_empty_range(find_limits(da, scale=self.norm))
-            for da in self.artists.values()
+            fix_empty_range(find_limits(artist._data, scale=self.norm))
+            for artist in self.artists.values()
         ]
         vmin = reduce(lambda a, b: min(a, b), [v[0] for v in limits])
         vmax = reduce(lambda a, b: max(a, b), [v[1] for v in limits])
@@ -213,6 +192,19 @@ class ColorMapper:
             self.vmax = maybe_variable_to_number(self.user_vmax, unit=self.unit)
         elif (vmax.value > self.vmax) or (self._autoscale == 'auto'):
             self.vmax = vmax.value
+
+    def _set_artists_colors(self, keys: Iterable):
+        """
+        Update the colors of all the artists apart from the one that triggered the
+        update, as those get updated by the figure.
+
+        Parameters
+        ----------
+        keys:
+            List of artists to update.
+        """
+        for k in keys:
+            self.artists[k].set_colors(self.rgba(self.artists[k].data))
 
     def _set_normalizer_limits(self):
         """
@@ -227,11 +219,10 @@ class ColorMapper:
             self.normalizer.vmin = self.vmin
             self.normalizer.vmax = self.vmax
 
-    def update(self):
+    def update(self, key: str, data: sc.DataArray):
         """
         Update the colorscale bounds taking into account new values.
-        If the bounds have changed, we update all the colors in the artists that depend
-        on this ColorMapper. We also update the colorbar widget if it exists.
+        We also update the colorbar widget if it exists.
 
         Parameters
         ----------
@@ -240,14 +231,33 @@ class ColorMapper:
         key:
             The id of the node that provided this data.
         """
+        if self.unit is None:
+            self.unit = data.unit
+        elif data.unit != self.unit:
+            raise ValueError(
+                f'Incompatible unit: colormapper has unit {self.unit}, '
+                f'new data has unit {data.unit}.'
+            )
+
+        if self.name is None:
+            self.name = data.name
+        elif data.name != self.name:
+            self.name = ''
+        if self.cax is not None:
+            text = self.name
+            if self.unit is not None:
+                text += f'{" " if self.name else ""}[{self.unit}]'
+            self.cax.set_ylabel(text)
         old_bounds = np.array([self.vmin, self.vmax])
         self.autoscale()
         self._set_normalizer_limits()
 
         if not np.allclose(old_bounds, np.array([self.vmin, self.vmax])):
             self._update_colorbar_widget()
-            return True
-        return False
+            keys = self.artists.keys()
+        else:
+            keys = [key]
+        self._set_artists_colors(keys)
 
     def toggle_norm(self):
         """
@@ -257,10 +267,9 @@ class ColorMapper:
         self.normalizer = _get_normalizer(self.norm)
         self.vmin = np.inf
         self.vmax = np.NINF
-        for artist in self.artists.values():
-            self.autoscale(data=artist._data)
+        self.autoscale()
         self._set_normalizer_limits()
-        self._set_artists_colors()
+        self._set_artists_colors(self.artists.keys())
         if self.colorbar is not None:
             self.colorbar.mappable.norm = self.normalizer
             self._update_colorbar_widget()

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -182,8 +182,8 @@ class ColorMapper:
             fix_empty_range(find_limits(artist._data, scale=self.norm))
             for artist in self.artists.values()
         ]
-        vmin = reduce(lambda a, b: min(a, b), [v[0] for v in limits])
-        vmax = reduce(lambda a, b: max(a, b), [v[1] for v in limits])
+        vmin = reduce(min, [v[0] for v in limits])
+        vmax = reduce(max, [v[1] for v in limits])
         if self.user_vmin is not None:
             self.vmin = maybe_variable_to_number(self.user_vmin, unit=self.unit)
         elif (vmin.value < self.vmin) or (self._autoscale == 'auto'):

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -250,14 +250,11 @@ class ColorMapper:
                 text += f'{" " if self.name else ""}[{self.unit}]'
             self.cax.set_ylabel(text)
 
-        if self._autoscale == 'grow':
-            old_bounds = np.array([self.vmin, self.vmax])
+        old_bounds = np.array([self.vmin, self.vmax])
         self.autoscale(data=data)
         self._set_normalizer_limits()
 
-        if (self._autoscale == 'auto') or (
-            not np.allclose(old_bounds, np.array([self.vmin, self.vmax]))
-        ):
+        if not np.allclose(old_bounds, np.array([self.vmin, self.vmax])):
             self._set_artists_colors(key=key)
             self._update_colorbar_widget()
 

--- a/src/plopp/graphics/figimage.py
+++ b/src/plopp/graphics/figimage.py
@@ -36,6 +36,10 @@ class FigImage(BaseFig):
     vmax:
         Upper bound for the colorbar. If a number (without a unit) is supplied, it is
         assumed that the unit is the same as the data unit.
+    autoscale:
+        The behavior of the color range limits. If ``auto``, the limits automatically
+        adjusts every time the data changes. If ``grow``, the limits are allowed to
+        grow with time but they do not shrink.
     scale:
         Control the scaling of the horizontal axis. For example, specify
         ``scale={'tof': 'log'}`` if you want log-scale for the ``tof`` dimension.
@@ -74,6 +78,7 @@ class FigImage(BaseFig):
         norm: Literal['linear', 'log'] = 'linear',
         vmin: Optional[Union[sc.Variable, int, float]] = None,
         vmax: Optional[Union[sc.Variable, int, float]] = None,
+        autoscale: Literal['auto', 'grow'] = 'auto',
         scale: Optional[Dict[str, str]] = None,
         aspect: Literal['auto', 'equal'] = 'auto',
         grid: bool = False,
@@ -99,6 +104,7 @@ class FigImage(BaseFig):
             norm=norm,
             vmin=vmin,
             vmax=vmax,
+            autoscale=autoscale,
             canvas=self.canvas,
         )
 

--- a/src/plopp/graphics/figimage.py
+++ b/src/plopp/graphics/figimage.py
@@ -151,6 +151,7 @@ class FigImage(BaseFig):
         if key not in self.artists:
             image = backends.image(canvas=self.canvas, data=new_values, **self._kwargs)
             self.artists[key] = image
+            self.colormapper[key] = image
             self.dims.update({"x": new_values.dims[1], "y": new_values.dims[0]})
 
             self.canvas.xunit = new_values.meta[new_values.dims[1]].unit
@@ -164,11 +165,7 @@ class FigImage(BaseFig):
                 self.canvas.yscale = self._scale[self.dims['y']]
 
         self.artists[key].update(new_values=new_values)
-        self.colormapper[key] = new_values
-        cmapper_range_changed = self.colormapper.update()
-        keys = self.artists.keys() if cmapper_range_changed else [key]
-        for k in keys:
-            self.artists[k].set_colors(self.colormapper.rgba(self.artists[k].data))
+        self.colormapper.update(key=key, data=new_values)
 
     def crop(self, **limits):
         """

--- a/src/plopp/graphics/figimage.py
+++ b/src/plopp/graphics/figimage.py
@@ -148,12 +148,9 @@ class FigImage(BaseFig):
                 ycoord, dim=self.dims['y'], unit=self.canvas.yunit
             )
 
-        self.colormapper.update(data=new_values, key=key)
-
         if key not in self.artists:
             image = backends.image(canvas=self.canvas, data=new_values, **self._kwargs)
             self.artists[key] = image
-            self.colormapper[key] = image
             self.dims.update({"x": new_values.dims[1], "y": new_values.dims[0]})
 
             self.canvas.xunit = new_values.meta[new_values.dims[1]].unit
@@ -167,7 +164,11 @@ class FigImage(BaseFig):
                 self.canvas.yscale = self._scale[self.dims['y']]
 
         self.artists[key].update(new_values=new_values)
-        self.artists[key].set_colors(self.colormapper.rgba(self.artists[key].data))
+        self.colormapper[key] = new_values
+        cmapper_range_changed = self.colormapper.update()
+        keys = self.artists.keys() if cmapper_range_changed else [key]
+        for k in keys:
+            self.artists[k].set_colors(self.colormapper.rgba(self.artists[k].data))
 
     def crop(self, **limits):
         """

--- a/src/plopp/graphics/figline.py
+++ b/src/plopp/graphics/figline.py
@@ -28,6 +28,10 @@ class FigLine(BaseFig):
     vmax:
         Upper bound for the vertical axis. If a number (without a unit) is supplied,
         it is assumed that the unit is the same as the current vertical axis unit.
+    autoscale:
+        The behavior of the axis limits. If ``auto``, the limits automatically
+        adjusts every time the data changes. If ``grow``, the limits are allowed to
+        grow with time but they do not shrink.
     scale:
         Control the scaling of the horizontal axis. For example, specify
         ``scale={'tof': 'log'}`` if you want log-scale for the ``tof`` dimension.
@@ -66,6 +70,7 @@ class FigLine(BaseFig):
         norm: Literal['linear', 'log'] = 'linear',
         vmin: Optional[Union[sc.Variable, int, float]] = None,
         vmax: Optional[Union[sc.Variable, int, float]] = None,
+        autoscale: Literal['auto', 'grow'] = 'auto',
         scale: Optional[Dict[str, str]] = None,
         errorbars: bool = True,
         mask_color: str = 'black',
@@ -92,6 +97,7 @@ class FigLine(BaseFig):
             title=title,
             vmin=vmin,
             vmax=vmax,
+            autoscale=autoscale,
             **kwargs
         )
         self.canvas.yscale = norm

--- a/src/plopp/graphics/figscatter3d.py
+++ b/src/plopp/graphics/figscatter3d.py
@@ -126,8 +126,6 @@ class FigScatter3d(BaseFig):
                 unit=self.canvas.zunit, copy=False
             )
 
-        self.colormapper.update(data=new_values, key=key)
-
         if key not in self.artists:
             pts = backends.point_cloud(
                 data=new_values, x=self._x, y=self._y, z=self._z, **self._kwargs
@@ -139,7 +137,7 @@ class FigScatter3d(BaseFig):
                 self.canvas.make_outline(limits=self.get_limits())
 
         self.artists[key].update(new_values=new_values)
-        self.artists[key].set_colors(self.colormapper.rgba(self.artists[key].data))
+        self.colormapper.update(key=key, data=new_values)
 
     def get_limits(self) -> Tuple[sc.Variable, sc.Variable, sc.Variable]:
         """

--- a/tests/backends/matplotlib/mpl_figimage_test.py
+++ b/tests/backends/matplotlib/mpl_figimage_test.py
@@ -24,7 +24,7 @@ def test_update_on_one_mesh_changes_colors_on_second_mesh():
     b = Node(da2)
     f = FigImage(a, b)
     old_b_colors = f.artists[b.id]._mesh.get_facecolors()
-    a.func = lambda: da1 * 1.1
+    a.func = lambda: da1 * 2.1
     a.notify_children('updated a')
     # No change because the update did not change the colorbar limits
     assert np.allclose(old_b_colors, f.artists[b.id]._mesh.get_facecolors())

--- a/tests/functions/slicer_test.py
+++ b/tests/functions/slicer_test.py
@@ -97,3 +97,15 @@ def test_raises_when_requested_keep_dims_do_not_exist():
         ValueError, match='Slicer plot: one or more of the requested dims to be kept'
     ):
         Slicer(da, keep=['time'])
+
+
+def test_autoscale_fixed():
+    da = sc.DataArray(
+        data=sc.arange('x', 5 * 10 * 20).fold(dim='x', sizes={'z': 20, 'y': 10, 'x': 5})
+    )
+    sl = Slicer(da, keep=['y', 'x'], autoscale='fixed')
+    assert sl.figure._fig.colormapper.vmin == 0
+    assert sl.figure._fig.colormapper.vmax == 5 * 10 * 20 - 1
+    sl.slider.controls['z']['slider'].value = 5
+    assert sl.figure._fig.colormapper.vmin == 0
+    assert sl.figure._fig.colormapper.vmax == 5 * 10 * 20 - 1

--- a/tests/graphics/colormapper_test.py
+++ b/tests/graphics/colormapper_test.py
@@ -260,30 +260,6 @@ def test_colorbar_cbar_false_overrides_cax():
     assert mapper.colorbar is None
 
 
-def test_data_with_different_unit_raises():
-    da1 = data_array(ndim=2, unit='K')
-    da2 = data_array(ndim=2, unit='m')
-    mapper = ColorMapper()
-    artist = DummyChild(da1)
-    key = 'data'
-    mapper[key] = artist
-    mapper.update(data=da1, key=key)
-    with pytest.raises(ValueError):
-        mapper.update(data=da2, key=key)
-
-
-def test_data_with_different_unit_if_initial_data_has_unit_none_raises():
-    da1 = data_array(ndim=2, unit=None)
-    da2 = data_array(ndim=2, unit='m')
-    mapper = ColorMapper()
-    artist = DummyChild(da1)
-    key = 'data'
-    mapper[key] = artist
-    mapper.update(data=da1, key=key)
-    with pytest.raises(ValueError):
-        mapper.update(data=da2, key=key)
-
-
 def test_autoscale_auto_vmin_set():
     da = data_array(ndim=2, unit='K')
     mapper = ColorMapper(autoscale='auto', vmin=-0.5)

--- a/tests/graphics/colormapper_test.py
+++ b/tests/graphics/colormapper_test.py
@@ -4,9 +4,9 @@
 from dataclasses import dataclass
 
 import numpy as np
+import pytest
 import scipp as sc
 from matplotlib.colors import LogNorm, Normalize
-import pytest
 
 from plopp.data.testing import data_array
 from plopp.graphics.colormapper import ColorMapper

--- a/tests/graphics/colormapper_test.py
+++ b/tests/graphics/colormapper_test.py
@@ -282,3 +282,33 @@ def test_data_with_different_unit_if_initial_data_has_unit_none_raises():
     mapper.update(data=da1, key=key)
     with pytest.raises(ValueError):
         mapper.update(data=da2, key=key)
+
+
+def test_autoscale_auto_vmin_set():
+    da = data_array(ndim=2, unit='K')
+    mapper = ColorMapper(autoscale='auto', vmin=-0.5)
+    artist = DummyChild(da)
+    key = 'data'
+    mapper[key] = artist
+    mapper.update(data=da, key=key)
+    assert mapper.vmin == -0.5
+    assert mapper.vmax == da.max().value
+    # Make sure it handles when da.max() is greater than vmin
+    mapper.update(data=da - sc.scalar(5.0, unit='K'), key=key)
+    assert mapper.vmin == -0.5
+    assert mapper.vmin < mapper.vmax
+
+
+def test_autoscale_auto_vmax_set():
+    da = data_array(ndim=2, unit='K')
+    mapper = ColorMapper(autoscale='auto', vmax=0.5)
+    artist = DummyChild(da)
+    key = 'data'
+    mapper[key] = artist
+    mapper.update(data=da, key=key)
+    assert mapper.vmax == 0.5
+    assert mapper.vmin == da.min().value
+    # Make sure it handles when da.min() is greater than vmax
+    mapper.update(data=da + sc.scalar(5.0, unit='K'), key=key)
+    assert mapper.vmax == 0.5
+    assert mapper.vmin < mapper.vmax

--- a/tests/graphics/colormapper_test.py
+++ b/tests/graphics/colormapper_test.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 
 import numpy as np
-import pytest
 import scipp as sc
 from matplotlib.colors import LogNorm, Normalize
 

--- a/tests/graphics/figline_test.py
+++ b/tests/graphics/figline_test.py
@@ -102,9 +102,21 @@ def test_update_grows_limits():
     assert new_lims[1] > old_lims[1]
 
 
-def test_update_does_not_shrink_limits():
+def test_update_does_shrink_limits_if_auto_mode():
     da = data_array(ndim=1)
-    fig = FigLine(Node(da))
+    fig = FigLine(Node(da), autoscale='auto')
+    old_lims = fig.canvas.yrange
+    key = list(fig.artists.keys())[0]
+    const = 0.5
+    fig.update(da * const, key=key)
+    new_lims = fig.canvas.yrange
+    assert new_lims[0] == old_lims[0] * const
+    assert new_lims[1] == old_lims[1] * const
+
+
+def test_update_does_not_shrink_limits_if_grow_mode():
+    da = data_array(ndim=1)
+    fig = FigLine(Node(da), autoscale='grow')
     old_lims = fig.canvas.yrange
     key = list(fig.artists.keys())[0]
     fig.update(da * 0.5, key=key)


### PR DESCRIPTION
By default, limits on the vertical axis (1d plots) and the colorbar (2d plots) will now fit to the currently displayed data, instead of having 'memory' and only be allowed to grow.
The old behaviour can be recovered by doing `autoscale='grow'`.

Fix #178 