### PR TITLE
Raise in slicer when too many keep dims are requested

### DIFF
--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -105,7 +105,8 @@ class Slicer:
         self.slice_nodes = [
             slice_dims(data_node, self.slider_node) for data_node in self.data_nodes
         ]
-        if len(keep) == 1:
+        ndims = len(keep)
+        if ndims == 1:
             self.figure = figure1d(
                 *self.slice_nodes,
                 crop=crop,
@@ -114,7 +115,7 @@ class Slicer:
                 vmax=vmax,
                 **kwargs,
             )
-        elif len(keep) == 2:
+        elif ndims == 2:
             self.figure = figure2d(
                 *self.slice_nodes,
                 crop=crop,
@@ -122,6 +123,11 @@ class Slicer:
                 vmin=vmin,
                 vmax=vmax,
                 **kwargs,
+            )
+        else:
+            raise ValueError(
+                f'Slicer plot: the number of dims to be kept must be 1 or 2, '
+                f'but {ndims} were requested.'
             )
 
 

--- a/src/plopp/functions/slicer.py
+++ b/src/plopp/functions/slicer.py
@@ -107,28 +107,22 @@ class Slicer:
         ]
         ndims = len(keep)
         if ndims == 1:
-            self.figure = figure1d(
-                *self.slice_nodes,
-                crop=crop,
-                autoscale=autoscale,
-                vmin=vmin,
-                vmax=vmax,
-                **kwargs,
-            )
+            make_figure = figure1d
         elif ndims == 2:
-            self.figure = figure2d(
-                *self.slice_nodes,
-                crop=crop,
-                autoscale=autoscale,
-                vmin=vmin,
-                vmax=vmax,
-                **kwargs,
-            )
+            make_figure = figure2d
         else:
             raise ValueError(
                 f'Slicer plot: the number of dims to be kept must be 1 or 2, '
                 f'but {ndims} were requested.'
             )
+        self.figure = make_figure(
+            *self.slice_nodes,
+            crop=crop,
+            autoscale=autoscale,
+            vmin=vmin,
+            vmax=vmax,
+            **kwargs,
+        )
 
 
 def slicer(

--- a/tests/functions/slicer_test.py
+++ b/tests/functions/slicer_test.py
@@ -88,7 +88,7 @@ def test_with_mismatching_data_arrays_raises():
 def test_raises_ValueError_when_given_binned_data():
     da = sc.data.table_xyz(100).bin(x=10, y=20)
     with pytest.raises(ValueError, match='Cannot plot binned data'):
-        Slicer(da, keep=['x'])
+        Slicer(da, keep=['xx'])
 
 
 def test_raises_when_requested_keep_dims_do_not_exist():
@@ -97,6 +97,18 @@ def test_raises_when_requested_keep_dims_do_not_exist():
         ValueError, match='Slicer plot: one or more of the requested dims to be kept'
     ):
         Slicer(da, keep=['time'])
+
+
+def test_raises_when_number_of_keep_dims_requested_is_bad():
+    da = data_array(ndim=4)
+    with pytest.raises(
+        ValueError, match='Slicer plot: the number of dims to be kept must be 1 or 2'
+    ):
+        Slicer(da, keep=['xx', 'yy', 'zz'])
+    with pytest.raises(
+        ValueError, match='Slicer plot: the list of dims to be kept cannot be empty'
+    ):
+        Slicer(da, keep=[])
 
 
 def test_autoscale_fixed():


### PR DESCRIPTION
Before these changes, if you requested 3 dims in `keep`, you would get this strange error
```
AttributeError: 'Slicer' object has no attribute 'figure'
```