### PR TITLE
Remove attrs use

### DIFF
--- a/src/plopp/backends/matplotlib/image.py
+++ b/src/plopp/backends/matplotlib/image.py
@@ -99,12 +99,12 @@ class Image:
         for i, k in enumerate('yx'):
             to_dim_search[k] = {
                 'dim': self._data.dims[i],
-                'var': self._data.meta[self._data.dims[i]],
+                'var': self._data.coords[self._data.dims[i]],
             }
             bin_edge_coords[k] = coord_as_bin_edges(self._data, self._data.dims[i])
             self._data_with_bin_edges.coords[self._data.dims[i]] = bin_edge_coords[k]
-            if self._data.meta[self._data.dims[i]].dtype == str:
-                string_labels[k] = self._data.meta[self._data.dims[i]]
+            if self._data.coords[self._data.dims[i]].dtype == str:
+                string_labels[k] = self._data.coords[self._data.dims[i]]
 
         self._dim_1d, self._dim_2d = _get_dims_of_1d_and_2d_coords(to_dim_search)
         self._mesh = None

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -59,7 +59,7 @@ class Line:
         self.label = data.name
         self._dim = self._data.dim
         self._unit = self._data.unit
-        self._coord = self._data.meta[self._dim]
+        self._coord = self._data.coords[self._dim]
         self._id = uuid.uuid4().hex
 
         aliases = {'ls': 'linestyle', 'lw': 'linewidth', 'c': 'color'}
@@ -171,7 +171,7 @@ class Line:
             self._ax.legend(**leg_args)
 
     def _make_data(self) -> dict:
-        x = self._data.meta[self._dim]
+        x = self._data.coords[self._dim]
         y = self._data.data
         hist = len(x) != len(y)
         error = None

--- a/src/plopp/backends/plotly/line.py
+++ b/src/plopp/backends/plotly/line.py
@@ -53,7 +53,7 @@ class Line:
         self.label = data.name
         self._dim = self._data.dim
         self._unit = self._data.unit
-        self._coord = self._data.meta[self._dim]
+        self._coord = self._data.coords[self._dim]
         self._id = uuid.uuid4().hex
 
         self._make_line(data=self._make_data(), number=number, **args)
@@ -177,7 +177,7 @@ class Line:
             self._error._plopp_id = self._id
 
     def _make_data(self) -> dict:
-        x = self._data.meta[self._dim]
+        x = self._data.coords[self._dim]
         y = self._data.data
         hist = len(x) != len(y)
         error = None

--- a/src/plopp/backends/pythreejs/point_cloud.py
+++ b/src/plopp/backends/pythreejs/point_cloud.py
@@ -61,7 +61,7 @@ class PointCloud:
 
         self._pixel_size = pixel_size
         if hasattr(self._pixel_size, 'unit'):
-            if len(set([self._data.meta[dim].unit for dim in [x, y, z]])) > 1:
+            if len(set([self._data.coords[dim].unit for dim in [x, y, z]])) > 1:
                 raise ValueError(
                     f'The supplied pixel_size has unit {self._pixel_size.unit}, but '
                     'the spatial coordinates do not all have the same units. In this '
@@ -69,7 +69,7 @@ class PointCloud:
                 )
             else:
                 self._pixel_size = self._pixel_size.to(
-                    dtype=float, unit=self._data.meta[x].unit
+                    dtype=float, unit=self._data.coords[x].unit
                 ).value
 
         self.geometry = p3.BufferGeometry(
@@ -77,15 +77,15 @@ class PointCloud:
                 'position': p3.BufferAttribute(
                     array=np.array(
                         [
-                            self._data.meta[self._x].values.astype('float32'),
-                            self._data.meta[self._y].values.astype('float32'),
-                            self._data.meta[self._z].values.astype('float32'),
+                            self._data.coords[self._x].values.astype('float32'),
+                            self._data.coords[self._y].values.astype('float32'),
+                            self._data.coords[self._z].values.astype('float32'),
                         ]
                     ).T
                 ),
                 'color': p3.BufferAttribute(
                     array=np.zeros(
-                        [self._data.meta[self._x].shape[0], 3], dtype='float32'
+                        [self._data.coords[self._x].shape[0], 3], dtype='float32'
                     )
                 ),
             }
@@ -130,9 +130,9 @@ class PointCloud:
         """
         Get the spatial extent of all the points in the cloud.
         """
-        xcoord = self._data.meta[self._x]
-        ycoord = self._data.meta[self._y]
-        zcoord = self._data.meta[self._z]
+        xcoord = self._data.coords[self._x]
+        ycoord = self._data.coords[self._y]
+        zcoord = self._data.coords[self._z]
         half_pixel = 0.5 * self._pixel_size
         dx = sc.scalar(half_pixel, unit=xcoord.unit)
         dy = sc.scalar(half_pixel, unit=ycoord.unit)

--- a/src/plopp/core/utils.py
+++ b/src/plopp/core/utils.py
@@ -25,10 +25,10 @@ def coord_as_bin_edges(da: sc.DataArray, key: str, dim: str = None) -> sc.Variab
     """
     if dim is None:
         dim = key
-    x = da.meta[key]
+    x = da.coords[key]
     if x.dtype == str:
         x = sc.arange(dim, float(x.shape[0]), unit=x.unit)
-    if da.meta.is_edges(key, dim=dim):
+    if da.coords.is_edges(key, dim=dim):
         return x
     if x.dtype in ('int32', 'int64'):
         x = x.to(dtype='float64')

--- a/src/plopp/data/factory.py
+++ b/src/plopp/data/factory.py
@@ -114,7 +114,6 @@ def data_array(
         )
         for i in range(ndim)
     }
-    attr_dict = {}
     mask_dict = {}
 
     if labels:

--- a/src/plopp/data/factory.py
+++ b/src/plopp/data/factory.py
@@ -58,7 +58,6 @@ def data_array(
     binedges: bool = False,
     labels: bool = False,
     masks: bool = False,
-    attrs: bool = False,
     ragged: bool = False,
     dtype: str = 'float64',
     unit: str = 'm/s',
@@ -83,8 +82,6 @@ def data_array(
         Add non-dimension coordinates if ``True``.
     masks:
         Add masks if ``True``.
-    attrs:
-        Add attributes if ``True``.
     ragged:
         Make one of the coordinates two-dimensional.
     dtype:
@@ -124,10 +121,6 @@ def data_array(
         coord_dict["lab"] = sc.linspace(
             data.dims[0], 101.0, 105.0, data.shape[0], unit='s'
         )
-    if attrs:
-        attr_dict["attr"] = sc.linspace(
-            data.dims[0], 10.0, 77.0, data.shape[0], unit='s'
-        )
     if masks:
         mask_dict["mask"] = sc.array(
             dims=data.dims, values=np.where(data.values > 0, True, False)
@@ -144,7 +137,7 @@ def data_array(
         coord_dict[data.dims[-1]] = sc.array(
             dims=data.dims, values=mesh[-1] + np.indices(mesh[-1].shape)[0]
         )
-    return sc.DataArray(data=data, coords=coord_dict, attrs=attr_dict, masks=mask_dict)
+    return sc.DataArray(data=data, coords=coord_dict, masks=mask_dict)
 
 
 def dataset(entries: List[str] = None, **kwargs) -> sc.Dataset:

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -54,7 +54,7 @@ def _to_data_array(
         raise ValueError(f"Cannot convert input of type {type(obj)} to a DataArray.")
     out = out.copy(deep=False)
     for dim, size in out.sizes.items():
-        if dim not in out.meta:
+        if dim not in out.coords:
             out.coords[dim] = sc.arange(dim, size, unit=None)
     return out
 
@@ -126,7 +126,7 @@ def preprocess(
         if isinstance(coords, str):
             coords = [coords]
         for dim in coords:
-            underlying = out.meta[dim].dims[-1]
+            underlying = out.coords[dim].dims[-1]
             renamed_dims[underlying] = dim
         out = out.rename_dims(**renamed_dims)
     for name, coord in out.coords.items():

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -93,15 +93,15 @@ def scatter3d(
                 f'x ({x}), y ({y}), and z ({z}) must be None.'
             )
         coords = {
-            (x := f'{pos}.x'): da.meta[pos].fields.x,
-            (y := f'{pos}.y'): da.meta[pos].fields.y,
-            (z := f'{pos}.z'): da.meta[pos].fields.z,
+            (x := f'{pos}.x'): da.coords[pos].fields.x,
+            (y := f'{pos}.y'): da.coords[pos].fields.y,
+            (z := f'{pos}.z'): da.coords[pos].fields.z,
         }
     else:
         x = x if x is not None else 'x'
         y = y if y is not None else 'y'
         z = z if z is not None else 'z'
-        coords = {k: da.meta[k] for k in (x, y, z)}
+        coords = {k: da.coords[k] for k in (x, y, z)}
 
     to_plot = sc.DataArray(data=da.data, masks=da.masks, coords=coords)
     if to_plot.ndim != 1:

--- a/src/plopp/plotting/superplot.py
+++ b/src/plopp/plotting/superplot.py
@@ -51,7 +51,7 @@ class LineSaveTool:
         self._fig.update(data, key=line_id)
         slice_values = self._slider_node.request_data()
         text = ', '.join(
-            f'{k}: {coord_element_to_string(data.meta[k])}'
+            f'{k}: {coord_element_to_string(data.coords[k])}'
             for k, it in slice_values.items()
         )
         line = self._fig.artists[line_id]

--- a/src/plopp/widgets/cut3d.py
+++ b/src/plopp/widgets/cut3d.py
@@ -216,7 +216,7 @@ class Cut3dTool(ipw.HBox):
                 (self.slider.max - self.slider.min) * self.thickness, unit=self._unit
             )
             pos = sc.scalar(self.slider.value, unit=self._unit)
-            selection = sc.abs(da.meta[self._dim] - pos) < delta
+            selection = sc.abs(da.coords[self._dim] - pos) < delta
             if selection.sum().value > 0:
                 self.select_nodes[n.id] = node(partial(select, s=selection))(da=n)
                 self.select_nodes[n.id].add_view(self._view)

--- a/src/plopp/widgets/slice.py
+++ b/src/plopp/widgets/slice.py
@@ -36,8 +36,8 @@ class SliceWidget(VBar):
 
         for dim in self._slider_dims:
             coord = (
-                da.meta[dim]
-                if dim in da.meta
+                da.coords[dim]
+                if dim in da.coords
                 else sc.arange(dim, da.sizes[dim], unit=None)
             )
             slider = ipw.IntSlider(

--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -15,7 +15,7 @@ def test_line_creation():
     assert line._unit == 'K'
     assert line._dim == 'xx'
     assert len(line._line.get_xdata()) == da.sizes['xx']
-    assert np.allclose(line._line.get_xdata(), da.meta['xx'].values)
+    assert np.allclose(line._line.get_xdata(), da.coords['xx'].values)
     assert np.allclose(line._line.get_ydata(), da.values)
     assert line._error is None
     assert not line._mask.get_visible()
@@ -35,7 +35,7 @@ def test_line_with_errorbars():
     x = np.array(coll.get_segments())[:, 0, 0]
     y1 = np.array(coll.get_segments())[:, 0, 1]
     y2 = np.array(coll.get_segments())[:, 1, 1]
-    assert np.allclose(x, da.meta['xx'].values)
+    assert np.allclose(x, da.coords['xx'].values)
     assert np.allclose(y1, (da.data - sc.stddevs(da.data)).values)
     assert np.allclose(y2, (da.data + sc.stddevs(da.data)).values)
 
@@ -45,7 +45,7 @@ def test_line_with_bin_edges_and_errorbars():
     line = Line(canvas=Canvas(), data=da)
     coll = line._error.get_children()[0]
     x = np.array(coll.get_segments())[:, 0, 0]
-    assert np.allclose(x, sc.midpoints(da.meta['xx']).values)
+    assert np.allclose(x, sc.midpoints(da.coords['xx']).values)
 
 
 def test_line_hide_errorbars():
@@ -78,10 +78,10 @@ def test_line_with_two_masks():
 def test_line_update():
     da = data_array(ndim=1)
     line = Line(canvas=Canvas(), data=da)
-    assert np.allclose(line._line.get_xdata(), da.meta['xx'].values)
+    assert np.allclose(line._line.get_xdata(), da.coords['xx'].values)
     assert np.allclose(line._line.get_ydata(), da.values)
     line.update(da * 2.5)
-    assert np.allclose(line._line.get_xdata(), da.meta['xx'].values)
+    assert np.allclose(line._line.get_xdata(), da.coords['xx'].values)
     assert np.allclose(line._line.get_ydata(), da.values * 2.5)
 
 
@@ -92,7 +92,7 @@ def test_line_update_with_errorbars():
     x = np.array(coll.get_segments())[:, 0, 0]
     y1 = np.array(coll.get_segments())[:, 0, 1]
     y2 = np.array(coll.get_segments())[:, 1, 1]
-    assert np.allclose(x, da.meta['xx'].values)
+    assert np.allclose(x, da.coords['xx'].values)
     assert np.allclose(y1, (da.data - sc.stddevs(da.data)).values)
     assert np.allclose(y2, (da.data + sc.stddevs(da.data)).values)
     new_values = da * 2.5

--- a/tests/backends/plotly/plotly_line_test.py
+++ b/tests/backends/plotly/plotly_line_test.py
@@ -18,7 +18,7 @@ def test_line_creation():
     assert line._unit == 'K'
     assert line._dim == 'xx'
     assert len(line._line.x) == da.sizes['xx']
-    assert np.allclose(line._line.x, da.meta['xx'].values)
+    assert np.allclose(line._line.x, da.coords['xx'].values)
     assert np.allclose(line._line.y, da.values)
     assert line._error is None
     assert not line._mask.visible
@@ -39,7 +39,7 @@ def test_line_with_errorbars():
 def test_line_with_bin_edges_and_errorbars():
     da = data_array(ndim=1, binedges=True, variances=True)
     line = Line(canvas=Canvas(), data=da)
-    assert np.allclose(line._error.x, sc.midpoints(da.meta['xx']).values)
+    assert np.allclose(line._error.x, sc.midpoints(da.coords['xx']).values)
 
 
 def test_line_hide_errorbars():
@@ -72,10 +72,10 @@ def test_line_with_two_masks():
 def test_line_update():
     da = data_array(ndim=1)
     line = Line(canvas=Canvas(), data=da)
-    assert np.allclose(line._line.x, da.meta['xx'].values)
+    assert np.allclose(line._line.x, da.coords['xx'].values)
     assert np.allclose(line._line.y, da.values)
     line.update(da * 2.5)
-    assert np.allclose(line._line.x, da.meta['xx'].values)
+    assert np.allclose(line._line.x, da.coords['xx'].values)
     assert np.allclose(line._line.y, da.values * 2.5)
 
 

--- a/tests/backends/pythreejs/pythreejs_point_cloud_test.py
+++ b/tests/backends/pythreejs/pythreejs_point_cloud_test.py
@@ -32,12 +32,12 @@ def test_get_limits():
     pix = 0.5
     cloud = PointCloud(data=da, x='x', y='y', z='z', pixel_size=pix)
     xlims, ylims, zlims = cloud.get_limits()
-    assert sc.identical(xlims[0], da.meta['x'].min() - sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(xlims[1], da.meta['x'].max() + sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(ylims[0], da.meta['y'].min() - sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(ylims[1], da.meta['y'].max() + sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(zlims[0], da.meta['z'].min() - sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(zlims[1], da.meta['z'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[0], da.coords['x'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[1], da.coords['x'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[0], da.coords['y'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[1], da.coords['y'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(zlims[0], da.coords['z'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(zlims[1], da.coords['z'].max() + sc.scalar(0.5 * pix, unit='m'))
 
 
 def test_get_limits_flat_panel():
@@ -46,10 +46,10 @@ def test_get_limits_flat_panel():
     pix = 0.5
     cloud = PointCloud(data=da, x='x', y='y', z='z', pixel_size=pix)
     xlims, ylims, zlims = cloud.get_limits()
-    assert sc.identical(xlims[0], da.meta['x'].min() - sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(xlims[1], da.meta['x'].max() + sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(ylims[0], da.meta['y'].min() - sc.scalar(0.5 * pix, unit='m'))
-    assert sc.identical(ylims[1], da.meta['y'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[0], da.coords['x'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(xlims[1], da.coords['x'].max() + sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[0], da.coords['y'].min() - sc.scalar(0.5 * pix, unit='m'))
+    assert sc.identical(ylims[1], da.coords['y'].max() + sc.scalar(0.5 * pix, unit='m'))
     assert sc.identical(zlims[0], sc.scalar(-0.5 * pix, unit='m'))
     assert sc.identical(zlims[1], sc.scalar(0.5 * pix, unit='m'))
 


### PR DESCRIPTION
Prepare for deprecation of `DataArray.attrs`.

The previous use of `attrs` that `plopp` cared about has anyway been changed previously: Unaligned coordinates are already stored in `coords` with unset alignment flag since Scipp 23.07. Therefore, I expect that this change has little impact.