### PR TITLE
Small fix in autoscaling limits with log scale

### DIFF
--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -13,25 +13,27 @@ def find_limits(
     """
     Find sensible limits, depending on linear or log scale.
     If there are no finite values in the array, raise an error.
-    If there are no positive values in the array, and the scale is log, raise an error.
+    If there are no positive values in the array, and the scale is log, fall back to
+    some sensible default values.
     """
     v = x.values
     finite_inds = np.isfinite(v)
     if np.sum(finite_inds) == 0:
         raise ValueError("No finite values were found in array. Cannot compute limits.")
     finite_vals = v[finite_inds]
+    finite_max = None
     if scale == "log":
         positives = finite_vals > 0
         if np.sum(positives) == 0:
-            raise ValueError(
-                "No positive values were found in array. Cannot compute log limits."
-            )
+            finite_min = 0.1
+            finite_max = 1.0
         else:
             initial = (np.finfo if v.dtype.kind == 'f' else np.iinfo)(v.dtype).max
             finite_min = np.amin(finite_vals, initial=initial, where=finite_vals > 0)
     else:
         finite_min = np.amin(finite_vals)
-    finite_max = np.amax(finite_vals)
+    if finite_max is None:
+        finite_max = np.amax(finite_vals)
     return (scalar(finite_min, unit=x.unit), scalar(finite_max, unit=x.unit))
 
 

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -66,10 +66,13 @@ def test_find_limits_all_zeros():
     assert sc.identical(lims[1], sc.scalar(0.0, unit='s'))
 
 
-def test_find_limits_all_zeros_log_raises():
+def test_find_limits_all_zeros_log_uses_default_positive_values():
     x = sc.zeros(sizes={'x': 5}, unit='s')
-    with pytest.raises(ValueError, match="No positive values were found in array"):
-        _ = find_limits(x, scale='log')
+    lims = find_limits(x, scale='log')
+    zero = sc.scalar(0.0, unit='s')
+    assert lims[0] > zero
+    assert lims[1] > zero
+    assert lims[0] < lims[1]
 
 
 def test_fix_empty_range():

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -59,6 +59,19 @@ def test_find_limits_no_finite_values_raises():
         _ = find_limits(x)
 
 
+def test_find_limits_all_zeros():
+    x = sc.zeros(sizes={'x': 5}, unit='s')
+    lims = find_limits(x)
+    assert sc.identical(lims[0], sc.scalar(0.0, unit='s'))
+    assert sc.identical(lims[1], sc.scalar(0.0, unit='s'))
+
+
+def test_find_limits_all_zeros_log_raises():
+    x = sc.zeros(sizes={'x': 5}, unit='s')
+    with pytest.raises(ValueError, match="No positive values were found in array"):
+        _ = find_limits(x, scale='log')
+
+
 def test_fix_empty_range():
     a = sc.scalar(5.0, unit='m')
     b = sc.scalar(10.0, unit='m')


### PR DESCRIPTION
Raise error when there are no positive values in limits search and scale is log.