### PR TITLE
Fix connecting draw tool to node

### DIFF
--- a/src/plopp/core/node.py
+++ b/src/plopp/core/node.py
@@ -44,7 +44,7 @@ class Node:
             key: p if isinstance(p, Node) else Node(p) for key, p in kwparents.items()
         }
         for parent in chain(self.parents, self.kwparents.values()):
-            parent.add_child(self)
+            parent.children.append(self)
         self._data = None
 
         if func_is_callable:
@@ -120,11 +120,19 @@ class Node:
             self._data = self.func(*args, **kwargs)
         return self._data
 
-    def add_child(self, child: Node):
+    def add_parent(self, parent: Node):
         """
-        Add a child to the node.
+        Add a parent to the node.
         """
-        self.children.append(child)
+        self.parents.append(parent)
+        parent.children.append(self)
+
+    def add_kwparent(self, key: str, parent: Node):
+        """
+        Add a keyword parent to the node.
+        """
+        self.kwparents[key] = parent
+        parent.children.append(self)
 
     def add_view(self, view: View):
         """

--- a/src/plopp/core/node.py
+++ b/src/plopp/core/node.py
@@ -120,19 +120,21 @@ class Node:
             self._data = self.func(*args, **kwargs)
         return self._data
 
-    def add_parent(self, parent: Node):
+    def add_parents(self, *parents: Node):
         """
-        Add a parent to the node.
+        Add one or more parents to the node.
         """
-        self.parents.append(parent)
-        parent.children.append(self)
+        for parent in parents:
+            self.parents.append(parent)
+            parent.children.append(self)
 
-    def add_kwparent(self, key: str, parent: Node):
+    def add_kwparents(self, **parents: Node):
         """
-        Add a keyword parent to the node.
+        Add one or more keyword parents to the node.
         """
-        self.kwparents[key] = parent
-        parent.children.append(self)
+        for key, parent in parents.items():
+            self.kwparents[key] = parent
+            parent.children.append(self)
 
     def add_view(self, view: View):
         """

--- a/src/plopp/widgets/drawing.py
+++ b/src/plopp/widgets/drawing.py
@@ -87,7 +87,7 @@ class DrawingTool(ToggleTool):
                 artist.color if hasattr(artist, 'color') else artist.edgecolor
             )
         elif isinstance(self._destination, Node):
-            self._destination.add_parent(output_node)
+            self._destination.add_parents(output_node)
             self._destination.notify_children(artist)
 
     def update_node(self, artist):

--- a/src/plopp/widgets/drawing.py
+++ b/src/plopp/widgets/drawing.py
@@ -87,8 +87,7 @@ class DrawingTool(ToggleTool):
                 artist.color if hasattr(artist, 'color') else artist.edgecolor
             )
         elif isinstance(self._destination, Node):
-            self._destination.parents.append(output_node)
-            output_node.add_child(self._destination)
+            self._destination.add_parent(output_node)
             self._destination.notify_children(artist)
 
     def update_node(self, artist):

--- a/src/plopp/widgets/drawing.py
+++ b/src/plopp/widgets/drawing.py
@@ -59,13 +59,13 @@ class DrawingTool(ToggleTool):
         super().__init__(callback=self.start_stop, value=value, **kwargs)
 
         self._figure = figure
-        self._destination_is_fig = is_figure(self._figure)
         self._input_node = input_node
         self._draw_nodes = {}
         self._output_nodes = {}
         self._func = func
         self._tool = tool(ax=self._figure.ax, autostart=False)
         self._destination = destination
+        self._destination_is_fig = is_figure(self._destination)
         self._get_artist_info = get_artist_info
         self._tool.on_create(self.make_node)
         self._tool.on_change(self.update_node)
@@ -88,6 +88,8 @@ class DrawingTool(ToggleTool):
             )
         elif isinstance(self._destination, Node):
             self._destination.parents.append(output_node)
+            output_node.add_child(self._destination)
+            self._destination.notify_children(artist)
 
     def update_node(self, artist):
         n = self._draw_nodes[artist.nodeid]

--- a/tests/core/node_test.py
+++ b/tests/core/node_test.py
@@ -309,3 +309,40 @@ def test_add_multiple_kwparents():
     assert d in a.children
     assert d in b.children
     assert d in c.children
+
+
+def test_adding_same_child_twice_raises():
+    a = Node(lambda: 5)
+    with pytest.raises(ValueError, match="Node .* is already a child in"):
+        Node(lambda x, y: x * y - 2, a, a)
+    with pytest.raises(ValueError, match="Node .* is already a child in"):
+        Node(lambda x, y: x * y - 2, x=a, y=a)
+
+
+def test_adding_same_parent_twice_raises():
+    a = Node(lambda: 5)
+    b = Node(lambda x, y: x * y - 2)
+    b.add_parents(a)
+    with pytest.raises(ValueError, match="Node .* is already a parent in"):
+        b.add_parents(a)
+
+
+def test_adding_same_parent_twice_at_once_raises():
+    a = Node(lambda: 5)
+    b = Node(lambda x, y: x * y - 2)
+    with pytest.raises(ValueError, match="Node .* is already a parent in"):
+        b.add_parents(a, a)
+
+
+def test_adding_same_kwparent_twice_raises():
+    a = Node(lambda: 5)
+    b = Node(lambda x, y: x * y - 2)
+    with pytest.raises(ValueError, match="Node .* is already a child in"):
+        b.add_kwparents(x=a, y=a)
+
+
+def test_adding_same_view_twice_raises():
+    a = Node(lambda: 15.0)
+    av = SimpleView(a)
+    with pytest.raises(ValueError, match="View .* is already a view in"):
+        a.add_view(av)

--- a/tests/core/node_test.py
+++ b/tests/core/node_test.py
@@ -259,3 +259,53 @@ def test_node_decorator_kwargs():
     b = Node(4.0)
     c = mult(x=a, y=b)
     assert c() == 24.0
+
+
+def test_add_parent():
+    a = Node(lambda: 5)
+    b = Node(lambda x: x - 2)
+    assert not a.children
+    assert not b.parents
+    assert not b.kwparents
+    b.add_parents(a)
+    assert a in b.parents
+    assert b in a.children
+
+
+def test_add_multiple_parents():
+    a = Node(lambda: 5.0)
+    b = Node(lambda: 12.0)
+    c = Node(lambda: -3.0)
+    d = Node(lambda x, y, z: x * y * z)
+    d.add_parents(a, b, c)
+    assert a in d.parents
+    assert b in d.parents
+    assert c in d.parents
+    assert d in a.children
+    assert d in b.children
+    assert d in c.children
+
+
+def test_add_kwparents():
+    a = Node(lambda: 5)
+    b = Node(lambda time: time * 101.0)
+    assert not a.children
+    assert not b.parents
+    assert not b.kwparents
+    b.add_kwparents(time=a)
+    assert a is b.kwparents['time']
+    assert b in a.children
+
+
+def test_add_multiple_kwparents():
+    a = Node(lambda: 5.0)
+    b = Node(lambda: 12.0)
+    c = Node(lambda: -3.0)
+    d = Node(lambda x, y, z: x * y * z)
+    d.add_kwparents(y=a, z=b, x=c)
+    assert a is d.kwparents['y']
+    assert b is d.kwparents['z']
+    assert c is d.kwparents['x']
+    assert d in a.children
+    assert d in b.children
+    assert d in c.children


### PR DESCRIPTION
When using the `add_child` method on a `Node`, this only appended to the list of children, but did not automatically update the list of parents/kwparents.

So we remove the `add_child` because it is somewhat ambiguous if the parent would then be added to the `parents` or `kwparents`. Instead, we replace it with two `add_parents` and `add_kwparents`.

We also fix the draw tool when the destination is a node and not a figure.