### PR TITLE
Override names in legend for inputs that are part of a dict

### DIFF
--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -160,7 +160,7 @@ def _all_dims_sorted(var, order='ascending'):
 
 def preprocess(
     obj: Union[Plottable, list],
-    name: str = '',
+    name: Optional[str] = None,
     ignore_size: bool = False,
     coords: Optional[List[str]] = None,
 ) -> sc.DataArray:
@@ -186,7 +186,8 @@ def preprocess(
     out = to_data_array(obj)
     check_not_binned(out)
     check_allowed_dtypes(out)
-    out.name = name
+    if name is not None:
+        out.name = name
     if not ignore_size:
         _check_size(out)
     if coords is not None:
@@ -232,7 +233,7 @@ def input_to_nodes(obj: PlottableMulti, processor: Callable) -> List[Node]:
     if hasattr(obj, 'items') and not is_pandas_series(obj):
         to_nodes = obj.items()
     else:
-        to_nodes = [('', obj)]
+        to_nodes = [(None, obj)]
     nodes = [Node(processor, inp, name=name) for name, inp in to_nodes]
     for node in nodes:
         if hasattr(processor, 'func'):

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -177,7 +177,7 @@ def preprocess(
     obj:
         The input object that will be plotted.
     name:
-        Override the input's name if it has none.
+        Override the input's name (when a dict-like structure is to be plotted).
     ignore_size:
         Do not perform a size check on the object before plotting it.
     coords:
@@ -186,8 +186,7 @@ def preprocess(
     out = to_data_array(obj)
     check_not_binned(out)
     check_allowed_dtypes(out)
-    if not out.name:
-        out.name = name
+    out.name = name
     if not ignore_size:
         _check_size(out)
     if coords is not None:
@@ -198,8 +197,8 @@ def preprocess(
             underlying = out.coords[dim].dims[-1]
             renamed_dims[underlying] = dim
         out = out.rename_dims(**renamed_dims)
-    for name, coord in out.coords.items():
-        if (coord.ndim == 0) or (name not in out.dims):
+    for n, coord in out.coords.items():
+        if (coord.ndim == 0) or (n not in out.dims):
             continue
         try:
             if not (
@@ -208,7 +207,7 @@ def preprocess(
             ):
                 warnings.warn(
                     'The input contains a coordinate with unsorted values '
-                    f'({name}). The results may be unpredictable. '
+                    f'({n}). The results may be unpredictable. '
                     'Coordinates can be sorted using '
                     '`scipp.sort(data, dim="to_be_sorted", order="ascending")`.',
                     RuntimeWarning,

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -3,7 +3,7 @@
 
 import uuid
 from functools import partial
-from typing import Literal, Optional, Tuple, Union
+from typing import Dict, Literal, Optional, Tuple, Union
 
 import scipp as sc
 
@@ -12,11 +12,20 @@ from ..graphics import Camera
 from .common import check_not_binned, from_compatible_lib, input_to_nodes
 
 
-def _to_variable(var, coords):
+def _to_variable(
+    var: Union[str, sc.Variable], coords: Dict[str, sc.Variable]
+) -> sc.Variable:
     return coords[var] if isinstance(var, str) else var
 
 
-def _preprocess_scatter(obj, x, y, z, pos, name=None):
+def _preprocess_scatter(
+    obj: PlottableMulti,
+    x: Union[str, sc.Variable],
+    y: Union[str, sc.Variable],
+    z: Union[str, sc.Variable],
+    pos: Union[str, sc.Variable],
+    name: Optional[str] = None,
+):
     da = from_compatible_lib(obj)
     check_not_binned(da)
 

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -25,7 +25,7 @@ def _preprocess_scatter(
     z: Union[str, sc.Variable],
     pos: Union[str, sc.Variable],
     name: Optional[str] = None,
-):
+) -> sc.DataArray:
     da = from_compatible_lib(obj)
     check_not_binned(da)
 

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -33,7 +33,8 @@ def _preprocess_scatter(obj, x, y, z, pos, name=None):
     out = sc.DataArray(data=da.data, masks=da.masks, coords=coords)
     if out.ndim != 1:
         out = out.flatten(to=uuid.uuid4().hex)
-    out.name = name
+    if name is not None:
+        out.name = name
     return out
 
 

--- a/tests/plotting/plot_test.py
+++ b/tests/plotting/plot_test.py
@@ -383,3 +383,17 @@ def test_hide_legend_bad_type():
     da2 = da1 * 3.3
     with pytest.raises(TypeError, match='Legend must be a bool, tuple, or a list'):
         pp.plot({'a': da1, 'b': da2}, legend='False')
+
+
+@pytest.mark.parametrize('Constructor', [dict, sc.Dataset, sc.DataGroup])
+def test_names_are_overridden_when_plotting_dicts(Constructor):
+    da1 = data_array(ndim=1)
+    da2 = da1 * 2
+    da1.name = "DA1"
+    da2.name = "DA2"
+    p = pp.plot(Constructor({'a': da1, 'b': da2}))
+    assert p.ax.get_legend().texts[0].get_text() == 'a'
+    assert p.ax.get_legend().texts[1].get_text() == 'b'
+    artists = list(p._view.artists.values())
+    assert artists[0].label == 'a'
+    assert artists[1].label == 'b'

--- a/tests/plotting/plot_test.py
+++ b/tests/plotting/plot_test.py
@@ -397,3 +397,5 @@ def test_names_are_overridden_when_plotting_dicts(Constructor):
     artists = list(p._view.artists.values())
     assert artists[0].label == 'a'
     assert artists[1].label == 'b'
+    assert da1.name == 'DA1'
+    assert da2.name == 'DA2'


### PR DESCRIPTION
Before, when we were passing data array in a dict, but they already had names, the keys in the dict would not be used in the legend.
This meant that for example
```Py
import plopp as pp
import scipp as sc

da1 = pp.data.data1d()
da2 = da1 * 2

da1.name = "DA1"
da2.name = "DA2"

pp.plot({'a': da1, 'b': da2})
```
would show `DA1` and `DA2` in the legend, which is confusing since you would think if you pass a dict, those keys would be used. The `.name` on a data array may have been sat in a very different place, if fx it was inserted in a `Dataset` many lines above in the notebook.

Now, the keys of the dict (or DataGroup) override the underlying names on the input.
Note that the inputs' names are not modified in-place.