### PR TITLE
Improve plot creation performance

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -11,7 +11,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ...core.limits import find_limits, fix_empty_range
 from ...core.utils import maybe_variable_to_number, scalar_to_string
-from .utils import fig_to_bytes, is_sphinx_build, silent_mpl_figure
+from .utils import fig_to_bytes, is_sphinx_build, make_figure
 
 
 def _none_if_not_finite(x):
@@ -96,10 +96,11 @@ class Canvas:
 
         if self.ax is None:
             self._own_axes = True
-            with silent_mpl_figure():
-                self.fig, self.ax = plt.subplots(
-                    figsize=(6.0, 4.0) if figsize is None else figsize
-                )
+            # self.fig = plt.Figure(figsize=(6.0, 4.0) if figsize is None else figsize)
+            # self.ax = self.fig.add_subplot()
+            self.fig, self.ax = make_figure(
+                figsize=(6.0, 4.0) if figsize is None else figsize
+            )
             if self.is_widget():
                 self.fig.canvas.toolbar_visible = False
                 self.fig.canvas.header_visible = False

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -96,11 +96,8 @@ class Canvas:
 
         if self.ax is None:
             self._own_axes = True
-            # self.fig = plt.Figure(figsize=(6.0, 4.0) if figsize is None else figsize)
-            # self.ax = self.fig.add_subplot()
-            self.fig, self.ax = make_figure(
-                figsize=(6.0, 4.0) if figsize is None else figsize
-            )
+            self.fig = make_figure(figsize=(6.0, 4.0) if figsize is None else figsize)
+            self.ax = self.fig.add_subplot()
             if self.is_widget():
                 self.fig.canvas.toolbar_visible = False
                 self.fig.canvas.header_visible = False

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -11,7 +11,7 @@ from matplotlib import gridspec
 
 from ..protocols import FigureLike
 from .static import get_repr_maker
-from .utils import copy_figure, is_interactive_backend, silent_mpl_figure
+from .utils import copy_figure, is_interactive_backend
 
 
 class Tiled:
@@ -73,13 +73,12 @@ class Tiled:
     ):
         self.nrows = nrows
         self.ncols = ncols
-        with silent_mpl_figure():
-            self.fig = plt.figure(
-                figsize=(min(6.0 * ncols, 15.0), min(4.0 * nrows, 15.0))
-                if figsize is None
-                else figsize,
-                layout='constrained',
-            )
+        self.fig = plt.Figure(
+            figsize=(min(6.0 * ncols, 15.0), min(4.0 * nrows, 15.0))
+            if figsize is None
+            else figsize,
+            layout='constrained',
+        )
         self.gs = gridspec.GridSpec(nrows, ncols, figure=self.fig, **kwargs)
         self.axes = []
         self.views = np.full((nrows, ncols), None)

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from typing import Optional, Tuple, Union
 
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import gridspec
 

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -11,7 +11,7 @@ from matplotlib import gridspec
 
 from ..protocols import FigureLike
 from .static import get_repr_maker
-from .utils import copy_figure, is_interactive_backend
+from .utils import copy_figure, is_interactive_backend, make_figure
 
 
 class Tiled:
@@ -73,12 +73,13 @@ class Tiled:
     ):
         self.nrows = nrows
         self.ncols = ncols
-        self.fig = plt.Figure(
+        self.fig = make_figure(
             figsize=(min(6.0 * ncols, 15.0), min(4.0 * nrows, 15.0))
             if figsize is None
             else figsize,
             layout='constrained',
         )
+
         self.gs = gridspec.GridSpec(nrows, ncols, figure=self.fig, **kwargs)
         self.axes = []
         self.views = np.full((nrows, ncols), None)

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from contextlib import contextmanager
 from io import BytesIO
 from typing import Literal
 
@@ -28,20 +27,12 @@ def fig_to_bytes(fig: Figure, form: Literal['png', 'svg'] = 'png') -> bytes:
     return buf.getvalue()
 
 
-@contextmanager
-def silent_mpl_figure():
-    """
-    Context manager to prevent automatic generation of figures in Jupyter.
-    """
-    backend_ = mpl.get_backend()
-    revert = False
-    if 'inline' in backend_:
-        mpl.use("Agg")
-        revert = True
-    with mpl.pyplot.ioff():
-        yield
-    if revert:
-        mpl.use(backend_)
+def make_figure(*args, **kwargs):
+    backend = mpl.get_backend()
+    manager = backend.new_figure_manager(*args, FigureClass=Figure, **kwargs)
+    fig = manager.canvas.figure
+    ax = fig.add_subplot()
+    return fig, ax
 
 
 def is_interactive_backend():

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -13,7 +13,7 @@ import scipp as sc
 from matplotlib.colorbar import ColorbarBase
 from matplotlib.colors import Colormap, LinearSegmentedColormap, LogNorm, Normalize
 
-from ..backends.matplotlib.utils import fig_to_bytes, silent_mpl_figure
+from ..backends.matplotlib.utils import fig_to_bytes
 from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import maybe_variable_to_number, merge_masks
 
@@ -129,8 +129,7 @@ class ColorMapper:
             if self.cax is None:
                 dpi = 100
                 height_inches = (figsize[1] / dpi) if figsize is not None else 6
-                with silent_mpl_figure():
-                    fig = plt.figure(figsize=(height_inches * 0.2, height_inches))
+                fig = plt.Figure(figsize=(height_inches * 0.2, height_inches))
                 self.cax = fig.add_axes([0.05, 0.02, 0.2, 0.98])
             self.colorbar = ColorbarBase(self.cax, cmap=self.cmap, norm=self.normalizer)
             self.cax.yaxis.set_label_coords(-0.9, 0.5)


### PR DESCRIPTION
In Jupyter, when creating a matplotlib figure with `plt.figure`, it is then automatically shown below the cell that contains the call to `plt.figure`.
This is undesired behaviour because we instead want the figure to be displayed when the figure repr is requested.

Until now, the workaround was to use a context manager to create the figure
```Py
@contextmanager
def silent_mpl_figure():
    """
    Context manager to prevent automatic generation of figures in Jupyter.
    """
    backend_ = mpl.get_backend()
    revert = False
    if 'inline' in backend_:
        mpl.use("Agg")
        revert = True
    with mpl.pyplot.ioff():
        yield
    if revert:
        mpl.use(backend_)
```
where we would temporarily switch to another backend before switching back.

This turns out to be an expensive operation, partly because when you switch backend, matplotlib closes all the existing figures (through `plt.close()`). And it gets more expensive the more figures you have.

This became very obvious when making a figure with 20 subplots in #286 using `Tiled`.

In this PR, we replace the old context manager with a function that makes a figure using `plt.Figure` instead of `plt.figure()`. This no longer automatically displays the created figure. Finally, when using the interactive `widget` backend, we have to do a bot more work, because the raw `plt.Figure` does not have a toolbar, nor is interactive.

Creating the 20 subplots now takes a little over 1s as opposed to 1 minute before.
As a bonus, running the unit tests now takes 30s instead of a minute :-)