### PR TITLE
feat: add option to not display masked data

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -150,6 +150,9 @@ class Canvas:
             self.ax.autoscale()
             xmin, xmax = self.ax.get_xlim()
             ymin, ymax = self.ax.get_ylim()
+            for line in self.ax.lines:
+                if hasattr(line, '_plopp_force_ylim'):
+                    ymin, ymax = line._plopp_force_ylim
         else:
             xmin = np.inf
             xmax = np.NINF

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -117,16 +117,12 @@ class Line:
             self._line = self._ax.step(
                 data['values']['x'][np.isnan(data['mask']['y'])],
                 data['values']['y'][np.isnan(data['mask']['y'])],
-                label=self.label,
-                zorder=10,
                 **{**default_step_style, **kwargs},
             )[0]
         else:
             self._line = self._ax.plot(
                 data['values']['x'][np.isnan(data['mask']['y'])],
                 data['values']['y'][np.isnan(data['mask']['y'])],
-                label=self.label,
-                zorder=10,
                 **{**default_plot_style, **kwargs},
             )[0]
 
@@ -136,8 +132,6 @@ class Line:
                 data['stddevs']['x'][m],
                 data['stddevs']['y'][m],
                 yerr=data['stddevs']['e'][m],
-                color=self._line.get_color(),
-                zorder=10,
                 fmt="none",
             )
 

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -25,12 +25,14 @@ def find_limits(
         m = np.ones_like(x.values, dtype='bool')
 
     v = x.values[m]
-    s = (
-        stddevs(x).values
-        if x.variances is not None
-        else np.zeros_like(x.values, dtype='bool')
-    )[m]
-    v = np.concatenate((v, v - s, v + s))
+    if x.ndim == 1:
+        # in case the plot is 1d, take the error bars into consideration
+        s = (
+            stddevs(x).values
+            if x.variances is not None
+            else np.zeros_like(x.values, dtype='bool')
+        )[m]
+        v = np.concatenate((v, v - s, v + s))
 
     v = v[np.isfinite(v)]
     if len(v) == 0:

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -47,7 +47,16 @@ def find_limits(
         finite_min = np.amin(v)
     if finite_max is None:
         finite_max = np.amax(v)
-    print(finite_min, finite_max)
+    # Padding only for 1d plots
+    if x.ndim == 1:
+        if scale == 'log':
+            p = (finite_max / finite_min) ** 0.05
+            finite_min /= p
+            finite_max *= p
+        else:
+            p = (finite_max - finite_min) * 0.05
+            finite_min -= p
+            finite_max += p
     return (scalar(finite_min, unit=x.unit), scalar(finite_max, unit=x.unit))
 
 

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Literal, Tuple
+from typing import Literal, Tuple, Union
 
 import numpy as np
-from scipp import Variable, scalar
+from scipp import DataArray, Variable, scalar, stddevs
+
+from .utils import merge_masks
 
 
 def find_limits(
-    x: Variable, scale: Literal['linear', 'log'] = 'linear'
+    x: Union[Variable, DataArray], scale: Literal['linear', 'log'] = 'linear'
 ) -> Tuple[Variable, ...]:
     """
     Find sensible limits, depending on linear or log scale.
@@ -16,24 +18,36 @@ def find_limits(
     If there are no positive values in the array, and the scale is log, fall back to
     some sensible default values.
     """
-    v = x.values
-    finite_inds = np.isfinite(v)
-    if np.sum(finite_inds) == 0:
+    m = np.ones_like(x.values, dtype='bool')
+    if isinstance(x, DataArray) and len(x.masks):
+        m &= ~merge_masks(x.masks).values
+    if not np.any(m):
+        m = np.ones_like(x.values, dtype='bool')
+
+    v = x.values[m]
+    s = (
+        stddevs(x).values
+        if x.variances is not None
+        else np.zeros_like(x.values, dtype='bool')
+    )[m]
+    v = np.concatenate((v, v - s, v + s))
+
+    v = v[np.isfinite(v)]
+    if len(v) == 0:
         raise ValueError("No finite values were found in array. Cannot compute limits.")
-    finite_vals = v[finite_inds]
     finite_max = None
     if scale == "log":
-        positives = finite_vals > 0
-        if np.sum(positives) == 0:
+        if not np.any(v > 0):
             finite_min = 0.1
             finite_max = 1.0
         else:
             initial = (np.finfo if v.dtype.kind == 'f' else np.iinfo)(v.dtype).max
-            finite_min = np.amin(finite_vals, initial=initial, where=finite_vals > 0)
+            finite_min = np.amin(v, initial=initial, where=v > 0)
     else:
-        finite_min = np.amin(finite_vals)
+        finite_min = np.amin(v)
     if finite_max is None:
-        finite_max = np.amax(finite_vals)
+        finite_max = np.amax(v)
+    print(finite_min, finite_max)
     return (scalar(finite_min, unit=x.unit), scalar(finite_max, unit=x.unit))
 
 

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -11,46 +11,46 @@ from plopp.core.limits import find_limits, fix_empty_range
 def test_find_limits():
     x = sc.arange('x', 11.0, unit='m')
     lims = find_limits(x)
-    assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(-0.5, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10.5, unit='m'))
 
 
 def test_find_limits_log():
     x = sc.arange('x', 11.0, unit='m')
     lims = find_limits(x, scale='log')
-    assert sc.identical(lims[0], sc.scalar(1.0, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(10**-0.05, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10**0.05, unit='m'))
 
 
 def test_find_limits_log_int():
     x = sc.arange('x', 11, unit='m')
     lims = find_limits(x, scale='log')
-    assert sc.identical(lims[0], sc.scalar(1, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(10**-0.05, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10**0.05, unit='m'))
 
 
 def test_find_limits_with_nan():
     x = sc.arange('x', 11.0, unit='m')
     x.values[5] = np.nan
     lims = find_limits(x)
-    assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(-0.5, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10.5, unit='m'))
 
 
 def test_find_limits_with_inf():
     x = sc.arange('x', 11.0, unit='m')
     x.values[5] = np.inf
     lims = find_limits(x)
-    assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(-0.5, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10.5, unit='m'))
 
 
 def test_find_limits_with_ninf():
     x = sc.arange('x', 11.0, unit='m')
     x.values[5] = np.NINF
     lims = find_limits(x)
-    assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(-0.5, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10.5, unit='m'))
 
 
 def test_find_limits_no_finite_values_raises():

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -18,15 +18,15 @@ def test_find_limits():
 def test_find_limits_log():
     x = sc.arange('x', 11.0, unit='m')
     lims = find_limits(x, scale='log')
-    assert sc.identical(lims[0], sc.scalar(10**-0.05, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10**0.05, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(1 / 10**0.05, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10 * 10**0.05, unit='m'))
 
 
 def test_find_limits_log_int():
     x = sc.arange('x', 11, unit='m')
     lims = find_limits(x, scale='log')
-    assert sc.identical(lims[0], sc.scalar(10**-0.05, unit='m'))
-    assert sc.identical(lims[1], sc.scalar(10**0.05, unit='m'))
+    assert sc.identical(lims[0], sc.scalar(1 / 10**0.05, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10 * 10**0.05, unit='m'))
 
 
 def test_find_limits_with_nan():


### PR DESCRIPTION
Fixes #266.
This still needs some more discussion.

1. Is it better to hide the data by setting it to `nan` instead of manually removing it using the masks? I opted for the manual option to make it distinct from non-masked nan-data.
2. Should this be default or do we keep the old default?
3. In what other plot-types should this option be added?