### PR TITLE
Ignore masked values for determining canvas and colorbar ranges

### DIFF
--- a/docs/gallery/scatter3d-with-slider.ipynb
+++ b/docs/gallery/scatter3d-with-slider.ipynb
@@ -93,6 +93,10 @@
     "slice_node = pw.slice_dims(data_array=da, slices=slider_node)\n",
     "\n",
     "fig = pp.figure3d(slice_node, pixel_size=0.3)\n",
+    "\n",
+    "# Set slider in the middle so panel isn't all dark\n",
+    "slider.controls['time']['slider'].value = 23\n",
+    "\n",
     "pp.widgets.Box([fig, slider])"
    ]
   },

--- a/docs/user-guide/customization/custom-interfaces.ipynb
+++ b/docs/user-guide/customization/custom-interfaces.ipynb
@@ -398,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.masks['below_300'] = da.data < sc.scalar(300.0, unit='K')\n",
+    "da.masks['close_to_300'] = abs(da.data - sc.scalar(300.0, unit='K')) < sc.scalar(1.0, unit='K')\n",
     "da.masks['large_x'] = da.coords['x'] > sc.scalar(150.0, unit='m')\n",
     "da"
    ]

--- a/docs/user-guide/customization/tweaking-figures.ipynb
+++ b/docs/user-guide/customization/tweaking-figures.ipynb
@@ -114,40 +114,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be10729a-08d0-4aec-8556-c6688c2c8386",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "### Setting the axis range\n",
-    "\n",
-    "Changing the range of an axis can be done by setting the `xrange` and `yrange` properties:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3bd58017-a1fe-4046-a760-3ee36e1b0f3d",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "p.canvas.xrange = [10, 40]\n",
-    "p.canvas.yrange = [-0.75, 1.5]\n",
-    "p"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a9a8ca49-7df0-4647-96af-8e709c328834",
    "metadata": {
     "editable": true,
@@ -180,6 +146,92 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c7080577-245c-43d1-97ac-1cd677963883",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Setting the axis range\n",
+    "\n",
+    "#### Vertical axis\n",
+    "\n",
+    "Changing the range of the vertical axis is done using the `vmin` and `vmax` arguments\n",
+    "(note that if only one of the two is given, then the other will be automatically determined from the data plotted)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "448bcedf-b92d-445e-8883-04395c63f1a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp.plot(da, vmin=sc.scalar(-0.5, unit='m/s'), vmax=sc.scalar(1.5, unit='m/s'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2931238-731f-4986-80ea-2dfe98bd16f1",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Note that if the unit in the supplied limits is not identical to the data units, an on-the-fly conversion is attempted.\n",
+    "It is also possible to omit the units altogether, in which case it is assumed the unit is the same as the data unit.\n",
+    "\n",
+    "#### Setting the horizontal axis range\n",
+    "\n",
+    "The easiest way to set the range of the horizontal axis is to slice the data before plotting:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bd58017-a1fe-4046-a760-3ee36e1b0f3d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pp.plot(da[10:40])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca82699b-b800-48f6-ab35-b9379c4ec654",
+   "metadata": {},
+   "source": [
+    "Note that this will add some padding around the plotted data points.\n",
+    "\n",
+    "If you wish to have precise control over the limits, you can use the lower-level `canvas.xrange` property:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "575940d9-767c-431f-a9d9-29d6df8ec5e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = da.plot()\n",
+    "p.canvas.xrange = [10, 40]\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "93c474b1-fcaa-4c96-b026-1e17ed278e72",
    "metadata": {
     "editable": true,
@@ -189,7 +241,10 @@
     "tags": []
    },
    "source": [
+    "Note that `camvas.yrange` is also available, and is equivalent to using the `vmin` and `vmax` arguments.\n",
+    "\n",
     "## Further modifications\n",
+    "\n",
     "Instead of providing keyword arguments for tweaking every aspect of the figures,\n",
     "we provide accessors to the underlying Matplotlib `Figure` and `Axes` objects,\n",
     "that can then directly be used to make the required modifications."
@@ -223,6 +278,7 @@
    },
    "outputs": [],
    "source": [
+    "p = da.plot()\n",
     "p.ax.set_yticks([-1.0, -0.5, 0, 0.5, 1.0])\n",
     "p.ax.set_yticklabels([r'$-\\pi$', r'$-\\pi / 2$', '0', r'$\\pi / 2$', r'$\\pi$'])\n",
     "p"
@@ -253,12 +309,12 @@
     "ax0 = fig.add_axes([0.0, 0.2, 1.0, 0.8])\n",
     "ax1 = fig.add_axes([0.0, 0.0, 1.0, 0.2])\n",
     "\n",
-    "pp.plot({'a': a, 'b': b}, ax=ax0)\n",
-    "pp.plot(a - b, ax=ax1)\n",
-    "\n",
     "ax0.xaxis.tick_top()\n",
     "ax0.xaxis.set_label_position('top')\n",
-    "ax1.set_ylabel('Residuals')"
+    "ax1.set_ylabel('Residuals')\n",
+    "\n",
+    "p1 = pp.plot({'a': a, 'b': b}, ax=ax0)\n",
+    "p2 = pp.plot(a - b, ax=ax1)"
    ]
   },
   {
@@ -301,8 +357,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/customization/tweaking-figures.ipynb
+++ b/docs/user-guide/customization/tweaking-figures.ipynb
@@ -187,7 +187,7 @@
     "Note that if the unit in the supplied limits is not identical to the data units, an on-the-fly conversion is attempted.\n",
     "It is also possible to omit the units altogether, in which case it is assumed the unit is the same as the data unit.\n",
     "\n",
-    "#### Setting the horizontal axis range\n",
+    "#### Horizontal axis\n",
     "\n",
     "The easiest way to set the range of the horizontal axis is to slice the data before plotting:"
    ]

--- a/docs/user-guide/plot-types/image-plot.ipynb
+++ b/docs/user-guide/plot-types/image-plot.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Basic image plot\n",
     "\n",
-    "As with one-dimensional data, plotting two-dimensional data is done using the [`plot`](../../reference/generated/plopp.plot.rst) function."
+    "As with one-dimensional data, plotting two-dimensional data is done using the [plot](../../reference/generated/plopp.plot.rst) function."
    ]
   },
   {

--- a/docs/user-guide/plot-types/image-plot.ipynb
+++ b/docs/user-guide/plot-types/image-plot.ipynb
@@ -24,7 +24,9 @@
    "id": "8487626a-2461-40c2-b0cd-42c6f82c9fab",
    "metadata": {},
    "source": [
-    "## Basic image plot"
+    "## Basic image plot\n",
+    "\n",
+    "As with one-dimensional data, plotting two-dimensional data is done using the [`plot`](../../reference/generated/plopp.plot.rst) function."
    ]
   },
   {
@@ -182,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')\n",
+    "da.masks['yband'] = abs(da.coords['y'] - sc.scalar(20, unit='m')) < sc.scalar(5, unit='m')\n",
     "da.plot()"
    ]
   },

--- a/docs/user-guide/plot-types/line-plot.ipynb
+++ b/docs/user-guide/plot-types/line-plot.ipynb
@@ -26,8 +26,8 @@
    "source": [
     "## Basic line plot\n",
     "\n",
-    "The most common way to plot data with Plopp is to use the `plot` function.\n",
-    "This can either be done using the `plopp.plot` free function,\n",
+    "The most common way to plot data with Plopp is to use the [`plot`](../../reference/generated/plopp.plot.rst) function.\n",
+    "This can either be done using the `plopp.plot()` free function,\n",
     "or calling the `.plot()` method on a Scipp data object (both are equivalent)."
    ]
   },

--- a/docs/user-guide/plot-types/line-plot.ipynb
+++ b/docs/user-guide/plot-types/line-plot.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Basic line plot\n",
     "\n",
-    "The most common way to plot data with Plopp is to use the [`plot`](../../reference/generated/plopp.plot.rst) function.\n",
+    "The most common way to plot data with Plopp is to use the [plot](../../reference/generated/plopp.plot.rst) function.\n",
     "This can either be done using the `plopp.plot()` free function,\n",
     "or calling the `.plot()` method on a Scipp data object (both are equivalent)."
    ]

--- a/docs/user-guide/plot-types/line-plot.ipynb
+++ b/docs/user-guide/plot-types/line-plot.ipynb
@@ -24,7 +24,11 @@
    "id": "8487626a-2461-40c2-b0cd-42c6f82c9fab",
    "metadata": {},
    "source": [
-    "## Basic line plot"
+    "## Basic line plot\n",
+    "\n",
+    "The most common way to plot data with Plopp is to use the `plot` function.\n",
+    "This can either be done using the `plopp.plot` free function,\n",
+    "or calling the `.plot()` method on a Scipp data object (both are equivalent)."
    ]
   },
   {
@@ -160,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.plot(da['x', 10:40])"
+    "da['x', 10:40].plot()"
    ]
   },
   {
@@ -170,8 +174,9 @@
    "source": [
     "## Overplotting\n",
     "\n",
-    "The plot function will accept a dict of data arrays as an input,\n",
-    "and will place all entries on the same axes."
+    "The `plot` function will accept a dict of data arrays as an input,\n",
+    "and will place all entries on the same axes\n",
+    "(as long as all entries have the same units and dimension labels)."
    ]
   },
   {
@@ -287,7 +292,7 @@
    "outputs": [],
    "source": [
     "da = pp.data.data1d()\n",
-    "da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')\n",
+    "da.masks['large-x'] = da.coords['x'] > sc.scalar(30, unit='m')\n",
     "pp.plot(da)"
    ]
   },
@@ -307,7 +312,7 @@
    "outputs": [],
    "source": [
     "da = pp.data.histogram1d()\n",
-    "da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')\n",
+    "da.masks['close-to-zero'] = abs(da.data) < sc.scalar(0.5, unit='m/s')\n",
     "pp.plot(da)"
    ]
   },

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import numpy as np
+import scipp as sc
+
+from ..core.limits import find_limits, fix_empty_range
+from ..core.utils import merge_masks
+
+
+def _none_min(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
+
+
+def _none_max(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
+@dataclass
+class BoundingBox:
+    """
+    A bounding box in 2D space.
+    """
+
+    xmin: Optional[float] = None
+    xmax: Optional[float] = None
+    ymin: Optional[float] = None
+    ymax: Optional[float] = None
+
+    def union(self, other: BoundingBox) -> BoundingBox:
+        """
+        Return the union of this bounding box with another one.
+        """
+        return BoundingBox(
+            xmin=_none_min(self.xmin, other.xmin),
+            xmax=_none_max(self.xmax, other.xmax),
+            ymin=_none_min(self.ymin, other.ymin),
+            ymax=_none_max(self.ymax, other.ymax),
+        )
+
+
+def get_canvas_bounding_box(
+    x: Optional[sc.DataArray],
+    y: Optional[sc.DataArray],
+    xscale: Literal['linear', 'log'],
+    yscale: Literal['linear', 'log'],
+    pad=False,
+) -> BoundingBox:
+    bounds = {}
+    if x is not None:
+        left, right = fix_empty_range(
+            find_limits(
+                x,
+                scale=xscale,
+                pad=pad,
+            )
+        )
+        bounds.update(xmin=left.value, xmax=right.value)
+    if y is not None:
+        bottom, top = fix_empty_range(
+            find_limits(
+                y,
+                scale=yscale,
+                pad=pad,
+            )
+        )
+        bounds.update(ymin=bottom.value, ymax=top.value)
+    return BoundingBox(**bounds)
+
+
+def make_line_data(data: sc.DataArray, dim: str) -> dict:
+    x = data.coords[dim]
+    y = data.data
+    hist = len(x) != len(y)
+    error = None
+    mask = {'x': x.values, 'y': np.full(y.shape, np.nan), 'visible': False}
+    if data.variances is not None:
+        error = {
+            'x': sc.midpoints(x).values if hist else x.values,
+            'y': y.values,
+            'e': sc.stddevs(y).values,
+        }
+    if len(data.masks):
+        one_mask = merge_masks(data.masks).values
+        mask = {
+            'x': x.values,
+            'y': np.where(one_mask, y.values, np.nan),
+            'visible': True,
+        }
+    if hist:
+        y = sc.concat([y[0:1], y], dim=dim)
+        if mask is not None:
+            mask['y'] = np.concatenate([mask['y'][0:1], mask['y']])
+    return {
+        'values': {'x': x.values, 'y': y.values},
+        'stddevs': error,
+        'mask': mask,
+        'hist': hist,
+    }

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Dict, Literal, Optional
 
 import numpy as np
 import scipp as sc
@@ -44,33 +44,15 @@ class BoundingBox:
         )
 
 
-def get_canvas_bounding_box(
-    x: Optional[sc.DataArray],
-    y: Optional[sc.DataArray],
-    xscale: Literal['linear', 'log'],
-    yscale: Literal['linear', 'log'],
+def axis_bounds(
+    keys: tuple[str, str],
+    x: sc.DataArray,
+    scale: Literal['linear', 'log'],
     pad=False,
-) -> BoundingBox:
-    bounds = {}
-    if x is not None:
-        left, right = fix_empty_range(
-            find_limits(
-                x,
-                scale=xscale,
-                pad=pad,
-            )
-        )
-        bounds.update(xmin=left.value, xmax=right.value)
-    if y is not None:
-        bottom, top = fix_empty_range(
-            find_limits(
-                y,
-                scale=yscale,
-                pad=pad,
-            )
-        )
-        bounds.update(ymin=bottom.value, ymax=top.value)
-    return BoundingBox(**bounds)
+) -> Dict[str, float]:
+    values = fix_empty_range(find_limits(x, scale=scale, pad=pad))
+    bounds = {k: v for k, v in zip(keys, (val.value for val in values))}
+    return bounds
 
 
 def make_line_data(data: sc.DataArray, dim: str) -> dict:

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Literal, Optional
+from typing import Dict, Literal, Optional, Tuple
 
 import numpy as np
 import scipp as sc
@@ -45,17 +45,47 @@ class BoundingBox:
 
 
 def axis_bounds(
-    keys: tuple[str, str],
+    keys: Tuple[str, str],
     x: sc.DataArray,
     scale: Literal['linear', 'log'],
     pad=False,
 ) -> Dict[str, float]:
+    """
+    Find sensible limits for an axis, depending on linear or log scale.
+
+    Parameters
+    ----------
+    keys:
+        The keys to use for constructing a bounding box. The keys should be
+        ``('xmin', 'xmax')`` for the horizontal axis, and ``('ymin', 'ymax')`` for the
+        vertical axis.
+    x:
+        The data array to find limits for.
+    scale:
+        The scale of the axis (linear or log).
+    pad:
+        Whether to pad the limits.
+    """
     values = fix_empty_range(find_limits(x, scale=scale, pad=pad))
     bounds = {k: v for k, v in zip(keys, (val.value for val in values))}
     return bounds
 
 
 def make_line_data(data: sc.DataArray, dim: str) -> dict:
+    """
+    Prepare data for plotting a line.
+    This includes extracting the x and y values, and optionally the error bars and masks
+    from the data array.
+    This also handles the case where the data array is a histogram, in which case the
+    first bin edge is repeated.
+
+    Parameters
+    ----------
+    data:
+        The data array to extract values from.
+    dim:
+        The dimension along which to extract values.
+    """
     x = data.coords[dim]
     y = data.data
     hist = len(x) != len(y)

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -13,20 +13,12 @@ from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import merge_masks
 
 
-def _none_min(a: Optional[float], b: Optional[float]) -> Optional[float]:
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return min(a, b)
+def _none_min(*args: float) -> float:
+    return min(x for x in args if x is not None)
 
 
-def _none_max(a: Optional[float], b: Optional[float]) -> Optional[float]:
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return max(a, b)
+def _none_max(*args: float) -> float:
+    return max(x for x in args if x is not None)
 
 
 @dataclass

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -9,7 +9,7 @@ import scipp as sc
 from matplotlib.collections import QuadMesh
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from ...core.limits import find_limits, fix_empty_range, BoundingBox
+from ...core.limits import BoundingBox, find_limits, fix_empty_range
 from ...core.utils import maybe_variable_to_number, scalar_to_string
 from .utils import fig_to_bytes, is_sphinx_build, make_figure
 

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -177,8 +177,7 @@ class Canvas:
             if hasattr(line, '_plopp_mask'):
                 line_mask = sc.array(dims=['x'], values=line._plopp_mask)
                 line_x = sc.DataArray(
-                    data=sc.array(dims=['x'], values=line.get_xdata()),
-                    masks={'mask': line_mask},
+                    data=sc.array(dims=['x'], values=line.get_xdata())
                 )
                 line_y = sc.DataArray(
                     data=sc.array(dims=['x'], values=line.get_ydata()),

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -14,7 +14,9 @@ from ...core.utils import maybe_variable_to_number, scalar_to_string
 from .utils import fig_to_bytes, is_sphinx_build, make_figure
 
 
-def _none_if_not_finite(x):
+def _none_if_not_finite(x: Union[float, int, None]) -> Union[float, int, None]:
+    if x is None:
+        return None
     return x if np.isfinite(x) else None
 
 

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -339,7 +339,7 @@ class Canvas:
         self.cax.set_ylabel(lab)
 
     @property
-    def xscale(self) -> str:
+    def xscale(self) -> Literal['linear', 'log']:
         """
         Get or set the scale of the x-axis ('linear' or 'log').
         """
@@ -350,7 +350,7 @@ class Canvas:
         self.ax.set_xscale(scale)
 
     @property
-    def yscale(self) -> str:
+    def yscale(self) -> Literal['linear', 'log']:
         """
         Get or set the scale of the y-axis ('linear' or 'log').
         """
@@ -427,7 +427,7 @@ class Canvas:
         self.ax.set_ylim(value)
 
     @property
-    def grid(self) -> str:
+    def grid(self) -> bool:
         """
         Get or set the visibility of the grid.
         """

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -148,6 +148,9 @@ class Line:
                 visible=data['mask']['visible'],
             )[0]
 
+        line_mask = ~np.isnan(data['mask']['y'])
+        self._line._plopp_mask = line_mask
+
         # Add error bars
         if errorbars and (data['stddevs'] is not None):
             self._error = self._ax.errorbar(
@@ -158,6 +161,8 @@ class Line:
                 zorder=10,
                 fmt="none",
             )
+            # Set the selection mask on the line collection that makes the segments
+            self._error[2][0]._plopp_mask = line_mask[1:] if data["hist"] else line_mask
 
         if self.label and self._canvas._legend:
             leg_args = {}

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -9,7 +9,7 @@ import scipp as sc
 from matplotlib.lines import Line2D
 from numpy.typing import ArrayLike
 
-from ...core.utils import merge_masks
+from ..common import make_line_data
 from .canvas import Canvas
 
 
@@ -54,7 +54,6 @@ class Line:
         self._line = None
         self._mask = None
         self._error = None
-        self._dim = None
         self._unit = None
         self.label = data.name
         self._dim = self._data.dim
@@ -67,7 +66,11 @@ class Line:
             if key in args:
                 args[alias] = args.pop(key)
 
-        self._make_line(data=self._make_data(), number=number, **args)
+        self._make_line(
+            data=make_line_data(data=self._data, dim=self._dim),
+            number=number,
+            **args,
+        )
 
     def _make_line(
         self,
@@ -175,36 +178,6 @@ class Line:
                 )
             self._ax.legend(**leg_args)
 
-    def _make_data(self) -> dict:
-        x = self._data.coords[self._dim]
-        y = self._data.data
-        hist = len(x) != len(y)
-        error = None
-        mask = {'x': x.values, 'y': np.full(y.shape, np.nan), 'visible': False}
-        if self._data.variances is not None:
-            error = {
-                'x': sc.midpoints(x).values if hist else x.values,
-                'y': y.values,
-                'e': sc.stddevs(y).values,
-            }
-        if len(self._data.masks):
-            one_mask = merge_masks(self._data.masks).values
-            mask = {
-                'x': x.values,
-                'y': np.where(one_mask, y.values, np.nan),
-                'visible': True,
-            }
-        if hist:
-            y = sc.concat([y[0:1], y], dim=self._dim)
-            if mask is not None:
-                mask['y'] = np.concatenate([mask['y'][0:1], mask['y']])
-        return {
-            'values': {'x': x.values, 'y': y.values},
-            'stddevs': error,
-            'mask': mask,
-            'hist': hist,
-        }
-
     def update(self, new_values: sc.DataArray):
         """
         Update the x and y positions of the data points from new data.
@@ -215,7 +188,7 @@ class Line:
             New data to update the line values, masks, errorbars from.
         """
         self._data = new_values
-        new_values = self._make_data()
+        new_values = make_line_data(data=self._data, dim=self._dim)
 
         self._line.set_data(new_values['values']['x'], new_values['values']['y'])
         self._mask.set_data(new_values['mask']['x'], new_values['mask']['y'])

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -180,7 +180,7 @@ class Line:
         y = self._data.data
         hist = len(x) != len(y)
         error = None
-        mask = {'x': x.values, 'y': y.values, 'visible': False}
+        mask = {'x': x.values, 'y': np.full_like(y.values, np.nan), 'visible': False}
         if self._data.variances is not None:
             error = {
                 'x': sc.midpoints(x).values if hist else x.values,
@@ -219,10 +219,7 @@ class Line:
 
         self._line.set_data(new_values['values']['x'], new_values['values']['y'])
         self._mask.set_data(new_values['mask']['x'], new_values['mask']['y'])
-        if new_values['mask']['visible']:
-            self._mask.set_visible(True)
-        else:
-            self._mask.set_visible(False)
+        self._mask.set_visible(new_values['mask']['visible'])
 
         if (self._error is not None) and (new_values['stddevs'] is not None):
             coll = self._error.get_children()[0]

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -180,7 +180,7 @@ class Line:
         y = self._data.data
         hist = len(x) != len(y)
         error = None
-        mask = {'x': x.values, 'y': np.full_like(y.values, np.nan), 'visible': False}
+        mask = {'x': x.values, 'y': np.full(y.shape, np.nan), 'visible': False}
         if self._data.variances is not None:
             error = {
                 'x': sc.midpoints(x).values if hist else x.values,

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -215,22 +215,22 @@ class Canvas:
         self.fig.layout.yaxis.title = lab
 
     @property
-    def xscale(self) -> str:
+    def xscale(self) -> Literal['linear', 'log']:
         """
         Get or set the scale of the x-axis ('linear' or 'log').
         """
-        return self.fig.layout.xaxis.type
+        return self.fig.layout.xaxis.type or 'linear'
 
     @xscale.setter
     def xscale(self, scale: Literal['linear', 'log']):
         self.fig.update_xaxes(type=scale)
 
     @property
-    def yscale(self) -> str:
+    def yscale(self) -> Literal['linear', 'log']:
         """
         Get or set the scale of the y-axis ('linear' or 'log').
         """
-        return self.fig.layout.yaxis.type
+        return self.fig.layout.yaxis.type or 'linear'
 
     @yscale.setter
     def yscale(self, scale: Literal['linear', 'log']):

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal, Tuple, Union
 
 import numpy as np
 import scipp as sc

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -7,7 +7,7 @@ import numpy as np
 import scipp as sc
 
 from ...core.utils import maybe_variable_to_number
-from ..common import BoundingBox, get_canvas_bounding_box
+from ..common import BoundingBox, axis_bounds
 
 
 class Canvas:
@@ -109,15 +109,11 @@ class Canvas:
                     dim='y',
                 )
             line_y = sc.DataArray(data=line_y, masks={'mask': line_mask})
-            bbox = bbox.union(
-                get_canvas_bounding_box(
-                    x=line_x,
-                    y=line_y,
-                    xscale=self.xscale,
-                    yscale=self.yscale,
-                    pad=True,
-                )
+            line_bbox = BoundingBox(
+                **{**axis_bounds(('xmin', 'xmax'), line_x, self.xscale, pad=True)},
+                **{**axis_bounds(('ymin', 'ymax'), line_y, self.yscale, pad=True)},
             )
+            bbox = bbox.union(line_bbox)
 
         self._bbox = self._bbox.union(bbox) if self._autoscale == 'grow' else bbox
         if self._user_vmin is not None:

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Literal, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
+import numpy as np
 import scipp as sc
 
 from ...core.utils import maybe_variable_to_number
+from ..common import BoundingBox, get_canvas_bounding_box
 
 
 class Canvas:
@@ -28,8 +30,10 @@ class Canvas:
         The maximum value for the vertical axis. If a number (without a unit) is
         supplied, it is assumed that the unit is the same as the current vertical axis
         unit.
-    cbar:
-        Add axes to host a colorbar if ``True``.
+    autoscale:
+        The behavior of the axis limits. If ``auto``, the limits automatically
+        adjusts every time the data changes. If ``grow``, the limits are allowed to
+        grow with time but they do not shrink.
     """
 
     def __init__(
@@ -38,7 +42,7 @@ class Canvas:
         title: str = None,
         vmin: Union[sc.Variable, int, float] = None,
         vmax: Union[sc.Variable, int, float] = None,
-        cbar: bool = False,
+        autoscale: Literal['auto', 'grow'] = 'auto',
         **ignored,
     ):
         # Note on the `**ignored`` keyword arguments: the figure which owns the canvas
@@ -77,8 +81,10 @@ class Canvas:
         self.units = {}
         self.dims = {}
         self._own_axes = False
+        self._autoscale = autoscale
         if title:
             self.title = title
+        self._bbox = BoundingBox()
 
     def to_widget(self):
         return self.fig
@@ -87,22 +93,59 @@ class Canvas:
         """
         Auto-scale the axes ranges to show all data in the canvas.
         """
-        ymin = None
-        ymax = None
-        if (self._user_vmin is not None) or (self._user_vmax is not None):
-            if None in (self._user_vmin, self._user_vmax):
-                raise ValueError(
-                    'With the Plotly backend, you have to specify both '
-                    'vmin and vmax.'
-                )
-            ymin = maybe_variable_to_number(self._user_vmin, unit=self.yunit)
-            ymax = maybe_variable_to_number(self._user_vmax, unit=self.yunit)
-            self.fig.update_layout(
-                yaxis={'autorange': False}, xaxis={'autorange': True}
+        bbox = BoundingBox()
+        lines = [trace for trace in self.fig.data if hasattr(trace, '_plopp_mask')]
+        for line in lines:
+            line_mask = sc.array(dims=['x'], values=line._plopp_mask)
+            line_x = sc.DataArray(data=sc.array(dims=['x'], values=line.x))
+            line_y = sc.DataArray(
+                data=sc.array(dims=['x'], values=line.y),
+                masks={'mask': line_mask},
             )
-            self.fig.update_yaxes(range=[ymin, ymax])
-        else:
-            self.fig.update_layout(yaxis={'autorange': True}, xaxis={'autorange': True})
+            bbox = bbox.union(
+                get_canvas_bounding_box(
+                    x=line_x,
+                    y=line_y,
+                    xscale=self.xscale,
+                    yscale=self.yscale,
+                    pad=True,
+                )
+            )
+            if line.error_y.array is not None:
+                for mult in [1, -1]:
+                    line_y = sc.DataArray(
+                        data=sc.array(
+                            dims=['x'], values=line.y + mult * line.error_y.array
+                        ),
+                        masks={'mask': line_mask},
+                    )
+                    bbox = bbox.union(
+                        get_canvas_bounding_box(
+                            x=None,
+                            y=line_y,
+                            xscale=self.xscale,
+                            yscale=self.yscale,
+                            pad=True,
+                        )
+                    )
+
+        self._bbox = self._bbox.union(bbox) if self._autoscale == 'grow' else bbox
+        if self._user_vmin is not None:
+            self._bbox.ymin = maybe_variable_to_number(
+                self._user_vmin, unit=self.units.get('y')
+            )
+        if self._user_vmax is not None:
+            self._bbox.ymax = maybe_variable_to_number(
+                self._user_vmax, unit=self.units.get('y')
+            )
+
+        xrange = np.array([self._bbox.xmin, self._bbox.xmax])
+        yrange = np.array([self._bbox.ymin, self._bbox.ymax])
+        if self.xscale == 'log':
+            xrange = np.log10(xrange)
+        if self.yscale == 'log':
+            yrange = np.log10(yrange)
+        self.fig.update_layout(xaxis_range=xrange, yaxis_range=yrange)
 
     def save(self, filename: str):
         """

--- a/src/plopp/backends/plotly/line.py
+++ b/src/plopp/backends/plotly/line.py
@@ -175,13 +175,12 @@ class Line:
             self._fig.add_trace(self._mask)
             self._mask = self._fig.data[-1]
         self._line._plopp_id = self._id
+        line_mask = ~np.isnan(data['mask']['y'])
+        self._line._plopp_mask = line_mask
         self._mask._plopp_id = self._id
         if self._error is not None:
             self._error._plopp_id = self._id
-
-        line_mask = ~np.isnan(data['mask']['y'])
-        self._line._plopp_mask = line_mask
-        self._error._plopp_mask = line_mask[1:] if data["hist"] else line_mask
+            self._error._plopp_mask = line_mask[1:] if data["hist"] else line_mask
 
     def update(self, new_values: sc.DataArray):
         """

--- a/src/plopp/backends/plotly/line.py
+++ b/src/plopp/backends/plotly/line.py
@@ -7,7 +7,7 @@ from typing import Dict
 import numpy as np
 import scipp as sc
 
-from ...core.utils import merge_masks
+from ..common import make_line_data
 from .canvas import Canvas
 
 
@@ -48,7 +48,6 @@ class Line:
         self._line = None
         self._mask = None
         self._error = None
-        self._dim = None
         self._unit = None
         self.label = data.name
         self._dim = self._data.dim
@@ -56,7 +55,11 @@ class Line:
         self._coord = self._data.coords[self._dim]
         self._id = uuid.uuid4().hex
 
-        self._make_line(data=self._make_data(), number=number, **args)
+        self._make_line(
+            data=make_line_data(data=self._data, dim=self._dim),
+            number=number,
+            **args,
+        )
 
     def _make_line(
         self,
@@ -176,35 +179,9 @@ class Line:
         if self._error is not None:
             self._error._plopp_id = self._id
 
-    def _make_data(self) -> dict:
-        x = self._data.coords[self._dim]
-        y = self._data.data
-        hist = len(x) != len(y)
-        error = None
-        mask = {'x': x.values, 'y': y.values, 'visible': False}
-        if self._data.variances is not None:
-            error = {
-                'x': sc.midpoints(x).values if hist else x.values,
-                'y': y.values,
-                'e': sc.stddevs(y).values,
-            }
-        if len(self._data.masks):
-            one_mask = merge_masks(self._data.masks).values
-            mask = {
-                'x': x.values,
-                'y': np.where(one_mask, y.values, np.nan),
-                'visible': True,
-            }
-        if hist:
-            y = sc.concat([y[0:1], y], dim=self._dim)
-            if mask is not None:
-                mask['y'] = np.concatenate([mask['y'][0:1], mask['y']])
-        return {
-            'values': {'x': x.values, 'y': y.values},
-            'stddevs': error,
-            'mask': mask,
-            'hist': hist,
-        }
+        line_mask = ~np.isnan(data['mask']['y'])
+        self._line._plopp_mask = line_mask
+        self._error._plopp_mask = line_mask[1:] if data["hist"] else line_mask
 
     def update(self, new_values: sc.DataArray):
         """
@@ -216,7 +193,7 @@ class Line:
             New data to update the line values, masks, errorbars from.
         """
         self._data = new_values
-        new_values = self._make_data()
+        new_values = make_line_data(data=self._data, dim=self._dim)
 
         with self._fig.batch_update():
             self._line.update(

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from __future__ import annotations
-
-from dataclasses import dataclass
 from typing import Literal, Optional, Tuple
 
 import numpy as np
@@ -12,47 +9,10 @@ import scipp as sc
 from .utils import merge_masks
 
 
-def _none_min(a: Optional[float], b: Optional[float]) -> Optional[float]:
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return min(a, b)
-
-
-def _none_max(a: Optional[float], b: Optional[float]) -> Optional[float]:
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return max(a, b)
-
-
-@dataclass
-class BoundingBox:
-    """
-    A bounding box in 2D space.
-    """
-
-    xmin: Optional[float] = None
-    xmax: Optional[float] = None
-    ymin: Optional[float] = None
-    ymax: Optional[float] = None
-
-    def union(self, other: BoundingBox) -> BoundingBox:
-        """
-        Return the union of this bounding box with another one.
-        """
-        return BoundingBox(
-            xmin=_none_min(self.xmin, other.xmin),
-            xmax=_none_max(self.xmax, other.xmax),
-            ymin=_none_min(self.ymin, other.ymin),
-            ymax=_none_max(self.ymax, other.ymax),
-        )
-
-
 def find_limits(
-    x: sc.DataArray, scale: Literal['linear', 'log'] = 'linear', pad: bool = False
+    x: sc.DataArray,
+    scale: Optional[Literal['linear', 'log']] = 'linear',
+    pad: bool = False,
 ) -> Tuple[sc.Variable, sc.Variable]:
     """
     Find sensible limits, depending on linear or log scale.
@@ -60,6 +20,8 @@ def find_limits(
     If there are no positive values in the array, and the scale is log, fall back to
     some sensible default values.
     """
+    if scale is None:
+        scale = 'linear'
     is_datetime = x.dtype == sc.DType.datetime64
     # Computing limits for string arrays is not supported, so we convert them to
     # dummy numerical arrays.

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -44,6 +44,11 @@ def find_limits(
     If there are no positive values in the array, and the scale is log, fall back to
     some sensible default values.
     """
+    # Computing limits for string arrays is not supported, so we convert them to
+    # dummy numerical arrays.
+    if x.dtype == str:
+        x = x.copy(deep=False)
+        x.data = sc.arange(x.dim, float(len(x)), unit=x.unit)
     if x.masks:
         x = sc.where(merge_masks(x.masks), sc.scalar(np.NaN, unit=x.unit), x.data)
     v = x.values

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -50,7 +50,11 @@ def find_limits(
         x = x.copy(deep=False)
         x.data = sc.arange(x.dim, float(len(x)), unit=x.unit)
     if x.masks:
-        x = sc.where(merge_masks(x.masks), sc.scalar(np.NaN, unit=x.unit), x.data)
+        x = sc.where(
+            merge_masks(x.masks),
+            sc.scalar(np.NaN, unit=x.unit),
+            x.data.to(dtype='float64'),
+        )
     v = x.values
     finite_inds = np.isfinite(v)
     if np.sum(finite_inds) == 0:

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -11,7 +11,7 @@ from .utils import merge_masks
 
 def find_limits(
     x: sc.DataArray,
-    scale: Optional[Literal['linear', 'log']] = 'linear',
+    scale: Literal['linear', 'log'] = 'linear',
     pad: bool = False,
 ) -> Tuple[sc.Variable, sc.Variable]:
     """
@@ -20,8 +20,6 @@ def find_limits(
     If there are no positive values in the array, and the scale is log, fall back to
     some sensible default values.
     """
-    if scale is None:
-        scale = 'linear'
     is_datetime = x.dtype == sc.DType.datetime64
     # Computing limits for string arrays is not supported, so we convert them to
     # dummy numerical arrays.

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Literal, Optional, Tuple
+from typing import Literal, Tuple
 
 import numpy as np
 import scipp as sc

--- a/src/plopp/core/limits.py
+++ b/src/plopp/core/limits.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Literal, Optional, Tuple
 
 import numpy as np
-
 import scipp as sc
 
 from .utils import merge_masks

--- a/src/plopp/graphics/lineview.py
+++ b/src/plopp/graphics/lineview.py
@@ -104,7 +104,6 @@ class LineView(View):
         self.canvas.yscale = norm
 
         self.render()
-        self.canvas.autoscale()
         self.canvas.finalize()
 
     def update(self, new_values: sc.DataArray, key: str):

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -9,72 +9,104 @@ from plopp.core.limits import find_limits, fix_empty_range
 
 
 def test_find_limits():
-    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
-    lims = find_limits(x)
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_log():
-    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
-    lims = find_limits(x, scale='log')
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    lims = find_limits(da, scale='log')
     assert sc.identical(lims[0], sc.scalar(1.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_log_int():
-    x = sc.DataArray(data=sc.arange('x', 11, unit='m'))
-    lims = find_limits(x, scale='log')
+    da = sc.DataArray(data=sc.arange('x', 11, unit='m'))
+    lims = find_limits(da, scale='log')
     assert sc.identical(lims[0], sc.scalar(1, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10, unit='m'))
 
 
 def test_find_limits_with_nan():
-    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
-    x.values[5] = np.nan
-    lims = find_limits(x)
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    da.values[5] = np.nan
+    lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_with_inf():
-    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
-    x.values[5] = np.inf
-    lims = find_limits(x)
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    da.values[5] = np.inf
+    lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_with_ninf():
-    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
-    x.values[5] = np.NINF
-    lims = find_limits(x)
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    da.values[5] = np.NINF
+    lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_no_finite_values_raises():
-    x = sc.DataArray(
+    da = sc.DataArray(
         data=sc.array(dims=['x'], values=[np.nan, np.inf, np.NINF, np.nan], unit='m')
     )
     with pytest.raises(ValueError, match="No finite values were found in array"):
-        _ = find_limits(x)
+        _ = find_limits(da)
 
 
 def test_find_limits_all_zeros():
-    x = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
-    lims = find_limits(x)
+    da = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
+    lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='s'))
     assert sc.identical(lims[1], sc.scalar(0.0, unit='s'))
 
 
 def test_find_limits_all_zeros_log_uses_default_positive_values():
-    x = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
-    lims = find_limits(x, scale='log')
+    da = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
+    lims = find_limits(da, scale='log')
     zero = sc.scalar(0.0, unit='s')
     assert lims[0] > zero
     assert lims[1] > zero
     assert lims[0] < lims[1]
+
+
+def test_find_limits_ignores_masks():
+    x = sc.arange('x', 11.0, unit='m')
+    da = sc.DataArray(data=x, masks={'mask': x > sc.scalar(5.0, unit='m')})
+    lims = find_limits(da)
+    assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(5.0, unit='m'))
+
+
+def test_find_limits_with_padding():
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    lims = find_limits(da, pad=True)
+    assert lims[0] < sc.scalar(0.0, unit='m')
+    assert lims[1] > sc.scalar(10.0, unit='m')
+
+
+def test_find_limits_with_padding_log():
+    da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
+    lims = find_limits(da, scale='log', pad=True)
+    assert lims[0] < sc.scalar(1.0, unit='m')
+    assert lims[0] > sc.scalar(0.0, unit='m')
+    assert lims[1] > sc.scalar(10.0, unit='m')
+
+
+def test_find_limits_with_strings():
+    da = sc.DataArray(
+        data=sc.array(dims=['x'], values=['a', 'b', 'c', 'd', 'e'], unit='K')
+    )
+    lims = find_limits(da)
+    assert sc.identical(lims[0], sc.scalar(0.0, unit='K'))
+    assert sc.identical(lims[1], sc.scalar(4.0, unit='K'))
 
 
 def test_fix_empty_range():

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -9,28 +9,28 @@ from plopp.core.limits import find_limits, fix_empty_range
 
 
 def test_find_limits():
-    x = sc.arange('x', 11.0, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     lims = find_limits(x)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_log():
-    x = sc.arange('x', 11.0, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     lims = find_limits(x, scale='log')
     assert sc.identical(lims[0], sc.scalar(1.0, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
 
 
 def test_find_limits_log_int():
-    x = sc.arange('x', 11, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11, unit='m'))
     lims = find_limits(x, scale='log')
     assert sc.identical(lims[0], sc.scalar(1, unit='m'))
     assert sc.identical(lims[1], sc.scalar(10, unit='m'))
 
 
 def test_find_limits_with_nan():
-    x = sc.arange('x', 11.0, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     x.values[5] = np.nan
     lims = find_limits(x)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
@@ -38,7 +38,7 @@ def test_find_limits_with_nan():
 
 
 def test_find_limits_with_inf():
-    x = sc.arange('x', 11.0, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     x.values[5] = np.inf
     lims = find_limits(x)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
@@ -46,7 +46,7 @@ def test_find_limits_with_inf():
 
 
 def test_find_limits_with_ninf():
-    x = sc.arange('x', 11.0, unit='m')
+    x = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     x.values[5] = np.NINF
     lims = find_limits(x)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='m'))
@@ -54,20 +54,22 @@ def test_find_limits_with_ninf():
 
 
 def test_find_limits_no_finite_values_raises():
-    x = sc.array(dims=['x'], values=[np.nan, np.inf, np.NINF, np.nan], unit='m')
+    x = sc.DataArray(
+        data=sc.array(dims=['x'], values=[np.nan, np.inf, np.NINF, np.nan], unit='m')
+    )
     with pytest.raises(ValueError, match="No finite values were found in array"):
         _ = find_limits(x)
 
 
 def test_find_limits_all_zeros():
-    x = sc.zeros(sizes={'x': 5}, unit='s')
+    x = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
     lims = find_limits(x)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='s'))
     assert sc.identical(lims[1], sc.scalar(0.0, unit='s'))
 
 
 def test_find_limits_all_zeros_log_uses_default_positive_values():
-    x = sc.zeros(sizes={'x': 5}, unit='s')
+    x = sc.DataArray(data=sc.zeros(sizes={'x': 5}, unit='s'))
     lims = find_limits(x, scale='log')
     zero = sc.scalar(0.0, unit='s')
     assert lims[0] > zero

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -85,6 +85,14 @@ def test_find_limits_ignores_masks():
     assert sc.identical(lims[1], sc.scalar(5.0, unit='m'))
 
 
+def test_find_limits_ignores_masks_log():
+    x = sc.arange('x', 11.0, unit='m')
+    da = sc.DataArray(data=x, masks={'mask': x < sc.scalar(3.0, unit='m')})
+    lims = find_limits(da)
+    assert sc.identical(lims[0], sc.scalar(3.0, unit='m'))
+    assert sc.identical(lims[1], sc.scalar(10.0, unit='m'))
+
+
 def test_find_limits_with_padding():
     da = sc.DataArray(data=sc.arange('x', 11.0, unit='m'))
     lims = find_limits(da, pad=True)
@@ -107,6 +115,16 @@ def test_find_limits_with_strings():
     lims = find_limits(da)
     assert sc.identical(lims[0], sc.scalar(0.0, unit='K'))
     assert sc.identical(lims[1], sc.scalar(4.0, unit='K'))
+
+
+def test_find_limits_datetime():
+    time = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    da = sc.DataArray(data=sc.array(dims=['time'], values=time))
+    lims = find_limits(da)
+    assert sc.identical(lims[0], sc.scalar(time[0], unit='s'))
+    assert sc.identical(lims[1], sc.scalar(time[-1], unit='s'))
 
 
 def test_fix_empty_range():

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -34,9 +34,6 @@ def test_plot_variable():
 
 def test_plot_data_array():
     pp.plot(data_array(ndim=1))
-    da = data_array(ndim=2)
-    pp.plot(da)
-    pp.plot(da)
 
 
 def test_plot_data_array_missing_coords():
@@ -67,9 +64,8 @@ def test_plot_dict_of_data_arrays():
     pp.plot({'a': ds['a'], 'b': ds['b']})
 
 
-@pytest.mark.parametrize('ndim', [1, 2])
-def test_plot_from_node(ndim):
-    da = data_array(ndim=ndim)
+def test_plot_from_node():
+    da = data_array(ndim=1)
     pp.plot(pp.Node(da))
 
 
@@ -90,12 +86,6 @@ def test_plot_mixing_raw_data_and_nodes():
     b = 13.3 * a
     pp.plot({'a': a, 'b': pp.Node(b)})
     pp.plot({'a': pp.Node(a), 'b': b})
-
-
-def test_plot_data_array_2d_with_one_missing_coord_and_binedges():
-    da = sc.data.table_xyz(100).bin(x=10, y=12).bins.mean()
-    del da.coords['x']
-    pp.plot(da)
 
 
 def test_plot_coord_with_no_unit():
@@ -119,18 +109,6 @@ def test_plot_ignore_size_disables_size_check():
 def test_plot_with_non_dimensional_unsorted_coord_does_not_warn():
     da = data_array(ndim=1)
     da.coords['aux'] = sc.sin(sc.arange(da.dim, 50.0, unit='rad'))
-    pp.plot(da)
-
-
-def test_plot_2d_coord():
-    da = data_array(ndim=2, ragged=True)
-    pp.plot(da)
-    pp.plot(da.transpose())
-
-
-def test_plot_2d_coord_with_mask():
-    da = data_array(ndim=2, ragged=True)
-    da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')
     pp.plot(da)
 
 
@@ -187,19 +165,6 @@ def test_kwarg_scale():
     assert p.canvas.ax.get_yscale() == 'linear'
 
 
-def test_kwarg_cmap():
-    da = data_array(ndim=2)
-    p = pp.plot(da, cmap='magma')
-    assert p._view.colormapper.cmap.name == 'magma'
-
-
-def test_kwarg_scale_2d():
-    da = data_array(ndim=2)
-    p = pp.plot(da, scale={'xx': 'log', 'yy': 'log'})
-    assert p.canvas.ax.get_xscale() == 'log'
-    assert p.canvas.ax.get_yscale() == 'log'
-
-
 def test_kwarg_for_two_lines():
     ds = dataset(ndim=1)
     p = pp.plot(ds, color='r')
@@ -219,7 +184,7 @@ def test_kwarg_as_dict():
 
 
 def test_raises_ValueError_when_given_binned_data():
-    da = sc.data.table_xyz(100).bin(x=10, y=20)
+    da = sc.data.table_xyz(100).bin(x=10)
     with pytest.raises(ValueError, match='Cannot plot binned data'):
         pp.plot(da)
 
@@ -232,17 +197,6 @@ def test_raises_ValueError_when_given_unsupported_data_type():
     nested_dict = {'group1': {'a': a, 'b': b}, 'group2': {'c': c, 'd': d}}
     with pytest.raises(TypeError, match='Cannot convert input of type'):
         pp.plot(nested_dict)
-
-
-def test_use_non_dimension_coords():
-    da = data_array(ndim=2, binedges=True)
-    da.coords['xx2'] = 7.5 * da.coords['xx']
-    da.coords['yy2'] = 3.3 * da.coords['yy']
-    p = pp.plot(da, coords=['xx2', 'yy2'])
-    assert p.canvas.dims['x'] == 'xx2'
-    assert p.canvas.dims['y'] == 'yy2'
-    assert p.canvas.xmax == 7.5 * da.coords['xx'].max().value
-    assert p.canvas.ymax == 3.3 * da.coords['yy'].max().value
 
 
 def test_use_non_dimension_coords_dataset():
@@ -263,30 +217,11 @@ def test_save_to_disk_1d(ext):
         assert os.path.isfile(fname)
 
 
-@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
-def test_save_to_disk_2d(ext):
-    da = data_array(ndim=2)
-    fig = pp.plot(da)
-    with tempfile.TemporaryDirectory() as path:
-        fname = os.path.join(path, f'plopp_fig2d.{ext}')
-        fig.save(filename=fname)
-        assert os.path.isfile(fname)
-
-
 def test_save_to_disk_with_bad_extension_raises():
-    da = data_array(ndim=2)
+    da = data_array(ndim=1)
     fig = pp.plot(da)
     with pytest.raises(ValueError):
-        fig.save(filename='plopp_fig2d.txt')
-
-
-def test_plot_raises_with_multiple_2d_inputs():
-    a = data_array(ndim=2)
-    b = 3.3 * a
-    with pytest.raises(
-        ValueError, match='The plot function can only plot a single 2d data entry'
-    ):
-        pp.plot({'a': a, 'b': b})
+        fig.save(filename='plopp_fig1d.txt')
 
 
 def test_plot_xarray_data_array_1d():
@@ -298,24 +233,6 @@ def test_plot_xarray_data_array_1d():
     da = xr.DataArray(data, coords={'time': time}, dims=['time'])
     p = pp.plot(da)
     assert p.canvas.dims['x'] == 'time'
-    assert p.canvas.units['x'] == 'dimensionless'
-    assert p.canvas.units['y'] == 'dimensionless'
-
-
-def test_plot_xarray_data_array_2d():
-    import xarray as xr
-
-    N = 50
-    M = 40
-    data = np.random.random([M, N])
-    time = np.arange(float(N))
-    space = np.arange(float(M))
-    da = xr.DataArray(
-        data, coords={'space': space, 'time': time}, dims=['space', 'time']
-    )
-    p = pp.plot(da)
-    assert p.canvas.dims['x'] == 'time'
-    assert p.canvas.dims['y'] == 'space'
     assert p.canvas.units['x'] == 'dimensionless'
     assert p.canvas.units['y'] == 'dimensionless'
 
@@ -423,32 +340,6 @@ def test_plot_1d_includes_masked_data_in_horizontal_range():
     p = pp.plot(da)
     # If we check only for > 5, padding may invalidate the test
     assert p.canvas.xmax > 10.0
-
-
-def test_plot_2d_ignores_masked_data_for_colorbar_range():
-    da = data_array(ndim=2)
-    da['xx', 10]['yy', 10].values = 100
-    da.masks['m'] = da.data > sc.scalar(5.0, unit='m/s')
-    p = pp.plot(da)
-    assert p._view.colormapper.vmax < 100
-
-
-def test_plot_2d_includes_masked_data_in_horizontal_range():
-    da = data_array(ndim=2)
-    da.masks['left'] = da.coords['xx'] < sc.scalar(5.0, unit='m')
-    da.masks['right'] = da.coords['xx'] > sc.scalar(30.0, unit='m')
-    p = pp.plot(da)
-    assert p.canvas.xmin < 1.0
-    assert p.canvas.xmax > 40.0
-
-
-def test_plot_2d_includes_masked_data_in_vertical_range():
-    da = data_array(ndim=2)
-    da.masks['bottom'] = da.coords['yy'] < sc.scalar(5.0, unit='m')
-    da.masks['top'] = da.coords['yy'] > sc.scalar(20.0, unit='m')
-    p = pp.plot(da)
-    assert p.canvas.ymin < 1.0
-    assert p.canvas.ymax > 30.0
 
 
 def test_plot_1d_datetime_coord():

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -9,7 +9,7 @@ import pytest
 import scipp as sc
 
 import plopp as pp
-from plopp.data.testing import variable, data_array, dataset
+from plopp.data.testing import variable, data_array
 
 
 def test_plot_ndarray():

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import scipp as sc
+
+import plopp as pp
+from plopp.data.testing import variable, data_array, dataset
+
+
+def test_plot_ndarray():
+    pp.plot(np.arange(50.0).reshape(5, 10))
+
+
+def test_plot_ndarray_int():
+    pp.plot(np.arange(50).reshape(5, 10))
+
+
+def test_plot_variable():
+    pp.plot(variable(ndim=2))
+
+
+def test_plot_data_array():
+    pp.plot(data_array(ndim=2))
+
+
+def test_plot_from_node():
+    da = data_array(ndim=2)
+    pp.plot(pp.Node(da))
+
+
+def test_plot_data_array_2d_with_one_missing_coord_and_binedges():
+    da = sc.data.table_xyz(100).bin(x=10, y=12).bins.mean()
+    del da.coords['x']
+    pp.plot(da)
+
+
+def test_plot_2d_coord():
+    da = data_array(ndim=2, ragged=True)
+    pp.plot(da)
+    pp.plot(da.transpose())
+
+
+def test_plot_2d_coord_with_mask():
+    da = data_array(ndim=2, ragged=True)
+    da.masks['negative'] = da.data < sc.scalar(0, unit='m/s')
+    pp.plot(da)
+
+
+def test_kwarg_cmap():
+    da = data_array(ndim=2)
+    p = pp.plot(da, cmap='magma')
+    assert p._view.colormapper.cmap.name == 'magma'
+
+
+def test_kwarg_scale_2d():
+    da = data_array(ndim=2)
+    p = pp.plot(da, scale={'xx': 'log', 'yy': 'log'})
+    assert p.canvas.ax.get_xscale() == 'log'
+    assert p.canvas.ax.get_yscale() == 'log'
+
+
+def test_raises_ValueError_when_given_binned_data():
+    da = sc.data.table_xyz(100).bin(x=10, y=20)
+    with pytest.raises(ValueError, match='Cannot plot binned data'):
+        pp.plot(da)
+
+
+def test_use_non_dimension_coords():
+    da = data_array(ndim=2, binedges=True)
+    da.coords['xx2'] = 7.5 * da.coords['xx']
+    da.coords['yy2'] = 3.3 * da.coords['yy']
+    p = pp.plot(da, coords=['xx2', 'yy2'])
+    assert p.canvas.dims['x'] == 'xx2'
+    assert p.canvas.dims['y'] == 'yy2'
+    assert p.canvas.xmax == 7.5 * da.coords['xx'].max().value
+    assert p.canvas.ymax == 3.3 * da.coords['yy'].max().value
+
+
+@pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
+def test_save_to_disk_2d(ext):
+    da = data_array(ndim=2)
+    fig = pp.plot(da)
+    with tempfile.TemporaryDirectory() as path:
+        fname = os.path.join(path, f'plopp_fig2d.{ext}')
+        fig.save(filename=fname)
+        assert os.path.isfile(fname)
+
+
+def test_save_to_disk_with_bad_extension_raises():
+    da = data_array(ndim=2)
+    fig = pp.plot(da)
+    with pytest.raises(ValueError):
+        fig.save(filename='plopp_fig2d.txt')
+
+
+def test_plot_raises_with_multiple_2d_inputs():
+    a = data_array(ndim=2)
+    b = 3.3 * a
+    with pytest.raises(
+        ValueError, match='The plot function can only plot a single 2d data entry'
+    ):
+        pp.plot({'a': a, 'b': b})
+
+
+def test_plot_xarray_data_array_2d():
+    import xarray as xr
+
+    N = 50
+    M = 40
+    data = np.random.random([M, N])
+    time = np.arange(float(N))
+    space = np.arange(float(M))
+    da = xr.DataArray(
+        data, coords={'space': space, 'time': time}, dims=['space', 'time']
+    )
+    p = pp.plot(da)
+    assert p.canvas.dims['x'] == 'time'
+    assert p.canvas.dims['y'] == 'space'
+    assert p.canvas.units['x'] == 'dimensionless'
+    assert p.canvas.units['y'] == 'dimensionless'
+
+
+def test_plot_2d_ignores_masked_data_for_colorbar_range():
+    da = data_array(ndim=2)
+    da['xx', 10]['yy', 10].values = 100
+    da.masks['m'] = da.data > sc.scalar(5.0, unit='m/s')
+    p = pp.plot(da)
+    assert p._view.colormapper.vmax < 100
+
+
+def test_plot_2d_includes_masked_data_in_horizontal_range():
+    da = data_array(ndim=2)
+    da.masks['left'] = da.coords['xx'] < sc.scalar(5.0, unit='m')
+    da.masks['right'] = da.coords['xx'] > sc.scalar(30.0, unit='m')
+    p = pp.plot(da)
+    assert p.canvas.xmin < 1.0
+    assert p.canvas.xmax > 40.0
+
+
+def test_plot_2d_includes_masked_data_in_vertical_range():
+    da = data_array(ndim=2)
+    da.masks['bottom'] = da.coords['yy'] < sc.scalar(5.0, unit='m')
+    da.masks['top'] = da.coords['yy'] > sc.scalar(20.0, unit='m')
+    p = pp.plot(da)
+    assert p.canvas.ymin < 1.0
+    assert p.canvas.ymax > 30.0
+
+
+def test_plot_2d_datetime_coord():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    z = sc.arange('z', 50.0, unit='m')
+    v = np.random.random(z.shape + time.shape)
+    da = sc.DataArray(
+        data=sc.array(dims=['z', 'time'], values=10 * v, variances=v),
+        coords={'time': time, 'z': z},
+    )
+    pp.plot(da)
+
+
+def test_plot_2d_datetime_coord_binedges():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    z = sc.arange('z', 50.0, unit='m')
+    v = np.random.random(z[:-1].shape + time[:-1].shape)
+    da = sc.DataArray(
+        data=sc.array(dims=['z', 'time'], values=10 * v, variances=v),
+        coords={'time': time, 'z': z},
+    )
+    pp.plot(da)

--- a/tests/plotting/plot_test.py
+++ b/tests/plotting/plot_test.py
@@ -449,3 +449,97 @@ def test_plot_2d_includes_masked_data_in_vertical_range():
     p = pp.plot(da)
     assert p.canvas.ymin < 1.0
     assert p.canvas.ymax > 30.0
+
+
+def test_plot_1d_datetime_coord():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'])
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+    )
+    pp.plot(da)
+
+
+def test_plot_1d_datetime_coord_binedges():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'] - 1)
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+    )
+    pp.plot(da)
+
+
+def test_plot_1d_datetime_coord_with_mask():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'])
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+        masks={'m': time > sc.datetime('2017-03-16T21:10:00')},
+    )
+    pp.plot(da)
+
+
+def test_plot_1d_datetime_coord_with_mask_and_binedges():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'] - 1)
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+        masks={'m': sc.midpoints(time) > sc.datetime('2017-03-16T21:10:00')},
+    )
+    pp.plot(da)
+
+
+def test_plot_1d_datetime_coord_log():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'])
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+    )
+    pp.plot(da, scale={'time': 'log'})
+
+
+def test_plot_1d_datetime_coord_log_binedges():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'] - 1)
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+    )
+    pp.plot(da, scale={'time': 'log'})
+
+
+def test_plot_1d_datetime_coord_log_with_mask():
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    v = np.random.rand(time.sizes['time'])
+    da = sc.DataArray(
+        data=sc.array(dims=['time'], values=10 * v, variances=v),
+        coords={'time': time},
+        masks={'m': time > sc.datetime('2017-03-16T21:10:00')},
+    )
+    pp.plot(da, scale={'time': 'log'})


### PR DESCRIPTION
Fixes #266 

As always, it turned out more complicated than expected. I needed to handle a bunch of different cases with coordinates that contain strings or datetimes.

For the latter, logscale on a datetime axis currently does not crash but no padding is applied.
It is an edge case anyway, and renders funny in matplotlib. I don't think it is very useful as a plot.
At least it doesn't crash so users can anyway set their own limits.
