### PR TITLE
Fix plotting with errorbars when nan values are present

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -169,11 +169,17 @@ class Canvas:
                 bbox = bbox.union(mesh_bbox)
 
             elif hasattr(c, '_plopp_mask'):
-                line_mask = sc.array(dims=['x'], values=c._plopp_mask)
+                segments = c.get_segments()
+                # Here get_segments() can return empty segments in the case where the
+                # data values are NaN, which we filter out.
+                lengths = np.array([len(segs) for segs in segments])
+                line_mask = sc.array(dims=['x'], values=c._plopp_mask[lengths > 0])
                 line_y = sc.DataArray(
                     data=sc.array(
                         dims=['x', 'y'],
-                        values=np.array(c.get_segments())[..., 1],
+                        values=np.array([s for (s, l) in zip(segments, lengths) if l])[
+                            ..., 1
+                        ],
                     ),
                     masks={'mask': line_mask},
                 )

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -434,3 +434,18 @@ def test_plot_1d_datetime_coord_log_with_mask():
         masks={'m': time > sc.datetime('2017-03-16T21:10:00')},
     )
     pp.plot(da, scale={'time': 'log'})
+
+
+def test_plot_1d_data_with_errorbars():
+    da = data_array(ndim=1, variances=True)
+    p = da.plot()
+    assert p.canvas.ymin < -1.0
+    assert p.canvas.ymax > 1.0
+
+
+def test_plot_1d_data_with_variances_and_nan_values():
+    da = data_array(ndim=1, variances=True)
+    da.values[-10:] = np.nan
+    p = da.plot()
+    assert p.canvas.ymin < -1.0
+    assert p.canvas.ymax > 1.0


### PR DESCRIPTION
This used to fail after #292 

```Py
import plopp as pp
import numpy as np

da = pp.data.data1d(variances=True)
da.values[-10:] = np.nan
da.plot()
```