### PR TITLE
Fix unpinned build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,11 @@ commands = pytest
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
-  plopp[all]
+  plopp
+  scipp
+  ipympl
+  pythreejs
+  mpltoolbox
   pytest
   graphviz
   kaleido


### PR DESCRIPTION
It seems list the syntax `pip install plopp[all]` does not work in `tox`?

See https://github.com/scipp/plopp/actions/runs/7523579139/job/20477153509 for failing builds.