### PR TITLE
Remove run dependency on scipp in conda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,7 +16,6 @@ requirements:
   run:
     - matplotlib
     - python>=3.9
-    - scipp
 
 test:
   imports:


### PR DESCRIPTION
Fixes #302

Do we still need a `run_constrained`? There is none in pyproject.toml...