### PR TITLE
Speed up the creation of plots with many lines

### DIFF
--- a/src/plopp/core/view.py
+++ b/src/plopp/core/view.py
@@ -50,7 +50,7 @@ class View:
         self.update(new_values=new_values, key=node_id)
 
     @abstractmethod
-    def update(self, new_values: sc.DataArray, key: str, draw: bool):
+    def update(self, new_values: sc.DataArray, key: str):
         """
         Update function which is called when a notification is received.
         This has to be overridden by any child class.

--- a/src/plopp/graphics/lineview.py
+++ b/src/plopp/graphics/lineview.py
@@ -103,6 +103,10 @@ class LineView(View):
         )
         self.canvas.yscale = norm
 
+        # The line view is potentially plotting many lines. When ``render`` is called,
+        # it calls ``update`` for each line. At the end of ``update``, a range autoscale
+        # is applied. We want to avoid autoscaling at the end of each ``update`` call,
+        # because searching for limits could be expensive.
         self._no_autoscale = True
         self.render()
         self._no_autoscale = False

--- a/src/plopp/graphics/lineview.py
+++ b/src/plopp/graphics/lineview.py
@@ -106,6 +106,7 @@ class LineView(View):
         self._no_autoscale = True
         self.render()
         self._no_autoscale = False
+        self.canvas.autoscale()
         self.canvas.finalize()
 
     def update(self, new_values: sc.DataArray, key: str):

--- a/src/plopp/graphics/lineview.py
+++ b/src/plopp/graphics/lineview.py
@@ -103,7 +103,9 @@ class LineView(View):
         )
         self.canvas.yscale = norm
 
+        self._no_autoscale = True
         self.render()
+        self._no_autoscale = False
         self.canvas.finalize()
 
     def update(self, new_values: sc.DataArray, key: str):
@@ -152,4 +154,5 @@ class LineView(View):
         else:
             self.artists[key].update(new_values=new_values)
 
-        self.canvas.autoscale()
+        if not self._no_autoscale:
+            self.canvas.autoscale()

--- a/src/plopp/graphics/scatter3dview.py
+++ b/src/plopp/graphics/scatter3dview.py
@@ -90,7 +90,7 @@ class Scatter3dView(View):
         self._original_artists = [n.id for n in nodes]
         self.render()
 
-    def update(self, new_values: sc.DataArray, key: str, draw=True):
+    def update(self, new_values: sc.DataArray, key: str):
         """
         Add new point cloud or update point cloud array with new values.
 
@@ -100,8 +100,6 @@ class Scatter3dView(View):
             New data to create or update a :class:`PointCloud` object from.
         key:
             The id of the node that sent the new data.
-        draw:
-            This argument is ignored for the 3d figure update.
         """
         mapping = {'x': self._x, 'y': self._y, 'z': self._z}
         if self.canvas.empty:


### PR DESCRIPTION
We now only autoscale once at the end during initial figure creation, as opposed to doing it for every new line that is plotted.
This speeds up plots that are showing multiple lines.

Example:
```Py
import scipp as sc
import plopp as pp

da = sc.data.binned_xy(1_000_000, 1000, 100)
d = sc.collapse(da.hist(), keep='x')

pp.plot(d)
```
The plotting call runtime goes down from ~2s to 300ms.

(Also removed an unused `draw` argument in the `View` api)