### PR TITLE
Better datetime axis compatibility

### DIFF
--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Literal, Optional, Tuple
 
-from matplotlib import dates as mdates
 import numpy as np
 import scipp as sc
+from matplotlib import dates as mdates
 
 from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import merge_masks

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Literal, Optional, Tuple
 
+from matplotlib import dates as mdates
 import numpy as np
 import scipp as sc
 
@@ -13,12 +14,16 @@ from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import merge_masks
 
 
+def _maybe_datetime_to_float(x):
+    return mdates.date2num(x) if np.issubdtype(x.dtype, np.datetime64) else x
+
+
 def _none_min(*args: float) -> float:
-    return min(x for x in args if x is not None)
+    return min(_maybe_datetime_to_float(x) for x in args if x is not None)
 
 
 def _none_max(*args: float) -> float:
-    return max(x for x in args if x is not None)
+    return max(_maybe_datetime_to_float(x) for x in args if x is not None)
 
 
 @dataclass
@@ -36,6 +41,11 @@ class BoundingBox:
         """
         Return the union of this bounding box with another one.
         """
+        # print('xmin', self.xmin, other.xmin)
+        # print('xmax', self.xmax, other.xmax)
+        # print('ymin', self.ymin, other.ymin)
+        # print('ymax', self.ymax, other.ymax)
+
         return BoundingBox(
             xmin=_none_min(self.xmin, other.xmin),
             xmax=_none_max(self.xmax, other.xmax),

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -41,10 +41,6 @@ class BoundingBox:
         """
         Return the union of this bounding box with another one.
         """
-        # print('xmin', self.xmin, other.xmin)
-        # print('xmax', self.xmax, other.xmax)
-        # print('ymin', self.ymin, other.ymin)
-        # print('ymax', self.ymax, other.ymax)
 
         return BoundingBox(
             xmin=_none_min(self.xmin, other.xmin),

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -8,22 +8,17 @@ from typing import Dict, Literal, Optional, Tuple
 
 import numpy as np
 import scipp as sc
-from matplotlib import dates as mdates
 
 from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import merge_masks
 
 
-def _maybe_datetime_to_float(x):
-    return mdates.date2num(x) if np.issubdtype(x.dtype, np.datetime64) else x
-
-
 def _none_min(*args: float) -> float:
-    return min(_maybe_datetime_to_float(x) for x in args if x is not None)
+    return min(x for x in args if x is not None)
 
 
 def _none_max(*args: float) -> float:
-    return max(_maybe_datetime_to_float(x) for x in args if x is not None)
+    return max(x for x in args if x is not None)
 
 
 @dataclass

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -6,12 +6,17 @@ from typing import Literal, Optional, Tuple, Union
 import matplotlib.pyplot as plt
 import numpy as np
 import scipp as sc
+from matplotlib import dates as mdates
 from matplotlib.collections import QuadMesh
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ...core.utils import maybe_variable_to_number, scalar_to_string
 from ..common import BoundingBox, axis_bounds
 from .utils import fig_to_bytes, is_sphinx_build, make_figure
+
+
+def _to_floats(x):
+    return mdates.date2num(x) if np.issubdtype(x.dtype, np.datetime64) else x
 
 
 def _none_if_not_finite(x: Union[float, int, None]) -> Union[float, int, None]:
@@ -149,9 +154,11 @@ class Canvas:
         lines = [line for line in self.ax.lines if hasattr(line, '_plopp_mask')]
         for line in lines:
             line_mask = sc.array(dims=['x'], values=line._plopp_mask)
-            line_x = sc.DataArray(data=sc.array(dims=['x'], values=line.get_xdata()))
+            line_x = sc.DataArray(
+                data=sc.array(dims=['x'], values=_to_floats(line.get_xdata()))
+            )
             line_y = sc.DataArray(
-                data=sc.array(dims=['x'], values=line.get_ydata()),
+                data=sc.array(dims=['x'], values=_to_floats(line.get_ydata())),
                 masks={'mask': line_mask},
             )
             line_bbox = BoundingBox(

--- a/src/plopp/backends/matplotlib/image.py
+++ b/src/plopp/backends/matplotlib/image.py
@@ -79,6 +79,7 @@ class Image:
         rasterized: bool = True,
         **kwargs,
     ):
+        print('image data:', data, data.coords['time'])
         self._canvas = canvas
         self._ax = self._canvas.ax
         self._data = data

--- a/src/plopp/backends/matplotlib/image.py
+++ b/src/plopp/backends/matplotlib/image.py
@@ -79,7 +79,6 @@ class Image:
         rasterized: bool = True,
         **kwargs,
     ):
-        print('image data:', data, data.coords['time'])
         self._canvas = canvas
         self._ax = self._canvas.ax
         self._data = data

--- a/tests/backends/matplotlib/mpl_figure_test.py
+++ b/tests/backends/matplotlib/mpl_figure_test.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import numpy as np
+import scipp as sc
 
 from plopp.backends.matplotlib import MatplotlibBackend
 from plopp.backends.matplotlib.interactive import InteractiveFig
 from plopp.backends.matplotlib.static import StaticFig
+from plopp.core import Node
 from plopp.graphics.imageview import ImageView
 from plopp.graphics.lineview import LineView
 
@@ -30,3 +33,27 @@ def test_create_interactive_fig2d(use_ipympl):
     b = MatplotlibBackend()
     fig = b.figure2d(View=ImageView)
     assert isinstance(fig, InteractiveFig)
+
+
+def test_datetime_compatibility_between_1d_and_2d_figures():
+    b = MatplotlibBackend()
+    # 2d data
+    t = np.arange(
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+    )
+    time = sc.array(dims=['time'], values=t)
+    z = sc.arange('z', 50.0, unit='m')
+    v = 10 * np.random.random(z.shape + time.shape)
+    da2d = sc.DataArray(
+        data=sc.array(dims=['z', 'time'], values=v), coords={'time': time, 'z': z}
+    )
+    fig = b.figure2d(ImageView, Node(da2d))
+    assert len(fig.ax.lines) == 0
+    assert len(fig.ax.collections) == 1
+
+    # 1d data
+    v = np.random.rand(time.sizes['time'])
+    da1d = sc.DataArray(data=sc.array(dims=['time'], values=v), coords={'time': time})
+    b.figure1d(LineView, Node(da1d), ax=fig.ax)
+    assert len(fig.ax.lines) > 0
+    assert len(fig.ax.collections) == 1

--- a/tests/backends/matplotlib/mpl_lineview_test.py
+++ b/tests/backends/matplotlib/mpl_lineview_test.py
@@ -44,7 +44,7 @@ def test_grid():
 
 
 def test_ax():
-    fig, ax = plt.subplots()
+    _, ax = plt.subplots()
     assert len(ax.lines) == 0
     da = data_array(ndim=1)
     _ = LineView(Node(da), ax=ax)


### PR DESCRIPTION
Computing limits on datetime axes is a little funny with data has that passed through matplotlib.
Datetimes are converted to floats for pcolormesh coordinates (2d images) but not for lines.

This PR tries to handle the different cases in a more consistent way, which allows us to plot 1d and 2d data on the same axes with datetime coords (which failed previously). It is not a common use case but was requested by users.

Example:
```Py
import plopp as pp
import numpy as np
import scipp as sc

# 2d data
t = np.arange(
    np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
)
time = sc.array(dims=['time'], values=t)
z = sc.arange('z', 50.0, unit='m')
v = np.random.random(z.shape + time.shape)
da = sc.DataArray(
    data=sc.array(dims=['z', 'time'], values=10 * v, variances=v),
    coords={'time': time, 'z': z},
)
f = pp.plot(da)

# 1d data
v = np.random.rand(time.sizes['time'])
a = sc.DataArray(
    data=sc.array(dims=['time'], values=10 * v, variances=v),
    coords={'time': time},
)
a.plot(ax=f.ax, color='r')
```
![Screenshot at 2024-02-22 16-51-54](https://github.com/scipp/plopp/assets/39047984/5e4bfeda-fe40-4eda-b808-abbf6b2f7dad)
