### PR TITLE
FIX: Add a hard coded width bound to the p3js canvas

### DIFF
--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -64,6 +64,7 @@ class Canvas:
         )
 
     def to_widget(self):
+        self.renderer.layout = ipw.Layout(max_width='80%', overflow='auto')
         return self.renderer
 
     def set_axes(self, dims, units, dtypes):


### PR DESCRIPTION
Fixes https://github.com/scipp/plopp/issues/169 (a hack-y one).

After some researching around about bouding canvases out of py3js it seems like this is the easiest
way of fixing the overflow problem of the canvas. A better solution would be to expose max_width from
py3js but I guess this is a minimal invasive change.

This does hard code the 80% width value but I guess we can expose that upstream to be user controllable
if the need arises.
