### PR TITLE
Add a couple of missing optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 scipp = ["scipp"]
-all = ["scipp", "ipympl", "pythreejs", "mpltoolbox"]
+all = ["scipp", "ipympl", "pythreejs", "mpltoolbox", "ipywidgets", "graphviz"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scipp/plopp/issues"


### PR DESCRIPTION
Note that `ipywidgets` was anyway included by `pythreejs`, but if one day we decide to move away from that, we would still need `ipywidgets` for the widgets.