### PR TITLE
Fix delayed removal of profiles in inspector plot

### DIFF
--- a/src/plopp/widgets/drawing.py
+++ b/src/plopp/widgets/drawing.py
@@ -102,6 +102,7 @@ class DrawingTool(ToggleTool):
         if self._destination_is_fig:
             self._destination.artists[output_node.id].remove()
             del self._destination.artists[output_node.id]
+            self._destination.canvas.draw()
         output_node.remove()
         draw_node.remove()
 


### PR DESCRIPTION
Removing a dot from inspector plot would only remove the profile in 1d plot below after e.g. new dot was marked or when we clicked Home in the toolbar.