### PR TITLE
The `_plopp_mask` on line objects needs to be updated after data update

### DIFF
--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -180,6 +180,9 @@ class Line:
         self._mask.set_data(new_values['mask']['x'], new_values['mask']['y'])
         self._mask.set_visible(new_values['mask']['visible'])
 
+        line_mask = ~np.isnan(new_values['mask']['y'])
+        self._line._plopp_mask = line_mask
+
         if (self._error is not None) and (new_values['stddevs'] is not None):
             coll = self._error.get_children()[0]
             coll.set_segments(
@@ -188,6 +191,9 @@ class Line:
                     _to_float(new_values['stddevs']['y']),
                     _to_float(new_values['stddevs']['e']),
                 )
+            )
+            self._error[2][0]._plopp_mask = (
+                line_mask[1:] if new_values["hist"] else line_mask
             )
 
     def _change_segments_y(self, x: ArrayLike, y: ArrayLike, e: ArrayLike) -> ArrayLike:

--- a/src/plopp/backends/plotly/line.py
+++ b/src/plopp/backends/plotly/line.py
@@ -192,11 +192,13 @@ class Line:
         """
         self._data = new_values
         new_values = make_line_data(data=self._data, dim=self._dim)
+        line_mask = ~np.isnan(new_values['mask']['y'])
 
         with self._fig.batch_update():
             self._line.update(
                 {'x': new_values['values']['x'], 'y': new_values['values']['y']}
             )
+            self._line._plopp_mask = line_mask
 
             if (self._error is not None) and (new_values['stddevs'] is not None):
                 self._error.update(
@@ -205,6 +207,9 @@ class Line:
                         'y': new_values['stddevs']['y'],
                         'error_y': {'array': new_values['stddevs']['e']},
                     }
+                )
+                self._error._plopp_mask = (
+                    line_mask[1:] if new_values["hist"] else line_mask
                 )
 
             if new_values['mask']['visible']:


### PR DESCRIPTION
`_plopp_mask` is a special property we have added on mpl Line object and is used to identify the points to consider when trying to autoscale the axes.
This was discovered when resizing rectangles in the [rectangle selection](https://scipp.github.io/plopp/gallery/rectangle-selection.html) notebook.

Not sure how to unit-test, as `pick` events currently [cannot be simulated](https://stackoverflow.com/questions/74771867/simulate-click-event-in-matplotlib-that-triggers-a-pick-event).
Suggestions welcome!