### PR TITLE
Fix image bounding box when coords are midpoints

### DIFF
--- a/src/plopp/backends/matplotlib/image.py
+++ b/src/plopp/backends/matplotlib/image.py
@@ -216,8 +216,8 @@ class Image:
         The bounding box of the image.
         """
         ydim, xdim = self._data.dims
-        image_x = self._data.coords[xdim]
-        image_y = self._data.coords[ydim]
+        image_x = self._data_with_bin_edges.coords[xdim]
+        image_y = self._data_with_bin_edges.coords[ydim]
 
         return BoundingBox(
             **{**axis_bounds(('xmin', 'xmax'), image_x, xscale)},

--- a/tests/backends/matplotlib/mpl_image_test.py
+++ b/tests/backends/matplotlib/mpl_image_test.py
@@ -34,3 +34,25 @@ def test_kwargs_are_forwarded_to_artist():
     fig = imagefigure(Node(da), rasterized=False)
     [artist] = fig.artists.values()
     assert not artist._mesh.get_rasterized()
+
+
+def test_bbox_midpoints():
+    da = data_array(ndim=2)
+    fig = imagefigure(Node(da))
+    [artist] = fig.artists.values()
+    bbox = artist.bbox(xscale='linear', yscale='linear')
+    assert bbox.xmin < da.coords['xx'].min().value
+    assert bbox.xmax > da.coords['xx'].max().value
+    assert bbox.ymin < da.coords['yy'].min().value
+    assert bbox.ymax > da.coords['yy'].max().value
+
+
+def test_bbox_binedges():
+    da = data_array(ndim=2, binedges=True)
+    fig = imagefigure(Node(da))
+    [artist] = fig.artists.values()
+    bbox = artist.bbox(xscale='linear', yscale='linear')
+    assert bbox.xmin == da.coords['xx'].min().value
+    assert bbox.xmax == da.coords['xx'].max().value
+    assert bbox.ymin == da.coords['yy'].min().value
+    assert bbox.ymax == da.coords['yy'].max().value


### PR DESCRIPTION
After the backend re-write, making an image with midpoint coordinates would clip off the edges of the image.
This PR fixes this.

Example:
```Py
import scipp as sc
import plopp as pp

da = pp.data.data2d()['y', :5]['x', :10]
da.plot()
```

**Before:**
![Screenshot at 2024-09-05 09-01-33](https://github.com/user-attachments/assets/8bc0e823-21d2-4ddc-ac04-3fb55840ec25)

**After:**
![Screenshot at 2024-09-05 09-01-07](https://github.com/user-attachments/assets/b6923510-e122-4919-bf7f-9ce749e2b462)
