### PR TITLE
Fix clipped figures in horizontal layout

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -134,19 +134,15 @@ class Canvas:
         return Image(value=fig_to_bytes(self.fig), format='png')
 
     def to_widget(self):
-        from ipywidgets import Layout, VBox
+        from ipywidgets import VBox
 
         if self.is_widget() and not is_sphinx_build():
             self.fig.tight_layout()
             # The Matplotlib canvas tries to fill the entire width of the output cell,
             # which can add unnecessary whitespace between it and other widgets. To
             # prevent this, we wrap the canvas in a VBox, which seems to help.
-            widget = VBox([self.fig.canvas])
-        else:
-            widget = self.to_image()
-        # The max_width is set to prevent overflow, see gh-169
-        widget.layout = Layout(max_width='80%', overflow='auto')
-        return widget
+            return VBox([self.fig.canvas])
+        return self.to_image()
 
     def draw(self):
         """

--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -72,7 +72,9 @@ class Canvas:
         )
 
     def to_widget(self):
-        # The max_width is set to prevent overflow, see gh-scipp/plopp/issues/169.
+        # The max_width is set to prevent overflow, see
+        # https://github.com/scipp/plopp/issues/169.
+        # See also https://github.com/scipp/plopp/pull/367.
         self.renderer.layout = ipw.Layout(max_width='100%', overflow='auto')
         return self.renderer
 

--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -72,8 +72,8 @@ class Canvas:
         )
 
     def to_widget(self):
-        # The max_width is set to prevent overflow, see gh-169
-        self.renderer.layout = ipw.Layout(max_width='80%', overflow='auto')
+        # The max_width is set to prevent overflow, see gh-scipp/plopp/issues/169.
+        self.renderer.layout = ipw.Layout(max_width='100%', overflow='auto')
         return self.renderer
 
     def set_axes(self, dims, units, dtypes):


### PR DESCRIPTION
Before:
![Screenshot at 2024-09-11 10-12-26](https://github.com/user-attachments/assets/db08e28c-a85e-439b-91ee-a777fe09b940)

After:
![Screenshot at 2024-09-11 10-11-54](https://github.com/user-attachments/assets/76509ae3-c1c7-417e-bea0-233342ea79d4)

I also made sure that the 100% layout for the 3d figures still makes sure the toolbar doesn't get hidden when the canvas gets too large.
