### PR TITLE
BUILD: kaleido should be python-kaleido for conda build

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,7 +35,7 @@ test:
 
   {# Conda does not allow spaces between package name and version, so remove them #}
   {% for package in test_dependencies %}
-    - {% if package == "graphviz" %}python-graphviz{% else %}{{ package|replace(" ", "") }}{% endif %}
+    - {% if package == "graphviz" %}python-graphviz{% elif package == "kaleido" %}python-kaleido{% else %}{{ package|replace(" ", "") }}{% endif %}
   {% endfor %}
 
 


### PR DESCRIPTION
We should probably change this upstream in the copier template, but I guess we can unblock the release build of plopp for now.