### PR TITLE
Raise error when two coords with same underlying dimension are used

### DIFF
--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -198,7 +198,7 @@ def preprocess(
             underlying = out.coords[dim].dims[-1]
             if underlying in renamed_dims:
                 raise ValueError(
-                    "coords: Cannot use the more than one coordinate associated with"
+                    "coords: Cannot use more than one coordinate associated with"
                     f"the same underlying dimension ({underlying})."
                 )
             renamed_dims[underlying] = dim

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -198,7 +198,7 @@ def preprocess(
             underlying = out.coords[dim].dims[-1]
             if underlying in renamed_dims:
                 raise ValueError(
-                    "coords: Cannot use more than one coordinate associated with"
+                    "coords: Cannot use more than one coordinate associated with "
                     f"the same underlying dimension ({underlying})."
                 )
             renamed_dims[underlying] = dim

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -196,6 +196,11 @@ def preprocess(
             coords = [coords]
         for dim in coords:
             underlying = out.coords[dim].dims[-1]
+            if underlying in renamed_dims:
+                raise ValueError(
+                    "coords: Cannot use the more than one coordinate associated with"
+                    f"the same underlying dimension ({underlying})."
+                )
             renamed_dims[underlying] = dim
         out = out.rename_dims(**renamed_dims)
     for n, coord in out.coords.items():

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -87,6 +87,16 @@ def test_use_non_dimension_coords():
     assert p.canvas.ymax == 3.3 * da.coords['yy'].max().value
 
 
+def test_use_two_coords_for_same_underlying_dimension_raises():
+    da = data_array(ndim=2)
+    da.coords['a'] = da.coords['xx'] * 2
+    msg = "coords: Cannot use the more than one coordinate"
+    with pytest.raises(ValueError, match=msg):
+        pp.plot(da, coords=['xx', 'a'])
+    with pytest.raises(ValueError, match=msg):
+        pp.plot(da, coords=['a', 'xx'])
+
+
 @pytest.mark.parametrize('ext', ['jpg', 'png', 'pdf', 'svg'])
 def test_save_to_disk_2d(ext):
     da = data_array(ndim=2)

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -90,7 +90,7 @@ def test_use_non_dimension_coords():
 def test_use_two_coords_for_same_underlying_dimension_raises():
     da = data_array(ndim=2)
     da.coords['a'] = da.coords['xx'] * 2
-    msg = "coords: Cannot use the more than one coordinate"
+    msg = "coords: Cannot use more than one coordinate"
     with pytest.raises(ValueError, match=msg):
         pp.plot(da, coords=['xx', 'a'])
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
Fixes #360