### PR TITLE
Better polar autoscale

### DIFF
--- a/docs/gallery/polar-plots.ipynb
+++ b/docs/gallery/polar-plots.ipynb
@@ -63,7 +63,6 @@
     "\n",
     "# Make the plot and tweak the axes\n",
     "polar1d = pp.plot(da, ax=ax, grid=True)\n",
-    "polar1d.canvas.xrange = 0, 2 * np.pi\n",
     "polar1d"
    ]
   },

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -31,6 +31,25 @@ def _cursor_formatter(x: float, dtype: sc.DType, unit: str) -> str:
     return scalar_to_string(sc.scalar(x, unit=unit))
 
 
+def _maybe_trim_polar_limits(
+    axis_type: str, limits: tuple[float, float]
+) -> tuple[float, float]:
+    """
+    If the axes are polar, trim the limits of the polar plot to be within the range
+    [0, 2π].
+
+    Parameters
+    ----------
+    axis_type:
+        The type of the axis. If this is not 'polar', the limits are returned as is.
+    limits:
+        The limits of the axis.
+    """
+    if axis_type != 'polar':
+        return limits
+    return tuple(np.clip(limits, 0, 2 * np.pi))
+
+
 class Canvas:
     """
     Matplotlib-based canvas used to render 2D graphics.
@@ -334,7 +353,9 @@ class Canvas:
 
     @xmin.setter
     def xmin(self, value: float):
-        self.ax.set_xlim(value, self.xmax)
+        self.ax.set_xlim(
+            _maybe_trim_polar_limits(axis_type=self.ax.name, limits=(value, self.xmax))
+        )
 
     @property
     def xmax(self) -> float:
@@ -345,7 +366,9 @@ class Canvas:
 
     @xmax.setter
     def xmax(self, value: float):
-        self.ax.set_xlim(self.xmin, value)
+        self.ax.set_xlim(
+            _maybe_trim_polar_limits(axis_type=self.ax.name, limits=(self.xmin, value))
+        )
 
     @property
     def xrange(self) -> tuple[float, float]:
@@ -356,7 +379,7 @@ class Canvas:
 
     @xrange.setter
     def xrange(self, value: tuple[float, float]):
-        self.ax.set_xlim(value)
+        self.ax.set_xlim(_maybe_trim_polar_limits(axis_type=self.ax.name, limits=value))
 
     @property
     def ymin(self) -> float:

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -108,19 +108,14 @@ class GraphicalView(View):
             bbox = bbox.union(artist.bbox(**scales))
         self.bbox = bbox
         self.bbox = self.bbox.override(self.canvas.bbox)
-        xrange = (
+        self.canvas.xrange = (
             _none_if_not_finite(self.bbox.xmin),
             _none_if_not_finite(self.bbox.xmax),
         )
-        yrange = (
+        self.canvas.yrange = (
             _none_if_not_finite(self.bbox.ymin),
             _none_if_not_finite(self.bbox.ymax),
         )
-        if self.canvas.ax.name == 'polar':
-            xrange = (max(xrange[0], 0), min(xrange[1], 2 * np.pi))
-            yrange = (max(yrange[0], 0), yrange[1])
-        self.canvas.xrange = xrange
-        self.canvas.yrange = yrange
         if hasattr(self.canvas, 'zrange'):
             self.canvas.zrange = (
                 _none_if_not_finite(self.bbox.zmin),

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -108,14 +108,19 @@ class GraphicalView(View):
             bbox = bbox.union(artist.bbox(**scales))
         self.bbox = bbox
         self.bbox = self.bbox.override(self.canvas.bbox)
-        self.canvas.xrange = (
+        xrange = (
             _none_if_not_finite(self.bbox.xmin),
             _none_if_not_finite(self.bbox.xmax),
         )
-        self.canvas.yrange = (
+        yrange = (
             _none_if_not_finite(self.bbox.ymin),
             _none_if_not_finite(self.bbox.ymax),
         )
+        if self.canvas.ax.name == 'polar':
+            xrange = (max(xrange[0], 0), min(xrange[1], 2 * np.pi))
+            yrange = (max(yrange[0], 0), yrange[1])
+        self.canvas.xrange = xrange
+        self.canvas.yrange = yrange
         if hasattr(self.canvas, 'zrange'):
             self.canvas.zrange = (
                 _none_if_not_finite(self.bbox.zmin),

--- a/tests/backends/matplotlib/mpl_plot_test.py
+++ b/tests/backends/matplotlib/mpl_plot_test.py
@@ -150,3 +150,40 @@ def test_with_strings_as_bin_edges_other_coord_is_bin_centers_2d():
     )
     fig = da.plot()
     assert [t.get_text() for t in fig.canvas.ax.get_xticklabels()] == strings
+
+
+def test_polar_axes_limits_with_padding_are_clipped():
+    # Make some spiral data
+    N = 50
+    r = sc.linspace('theta', 0, 10, N, unit='m')
+    theta = sc.linspace('theta', 0, 0.995 * 2 * np.pi, N, unit='rad')
+    da = sc.DataArray(data=r, coords={'theta': theta})
+
+    _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    fig = pp.plot(da, ax=ax)
+    assert fig.canvas.xrange == (0, 2 * np.pi)
+
+
+def test_polar_axes_limits_more_than_two_pi_are_clipped():
+    # Make some spiral data
+    N = 50
+    r = sc.linspace('theta', 0, 10, N, unit='m')
+    theta = sc.linspace('theta', 0, 3.5 * 2 * np.pi, N, unit='rad')
+    da = sc.DataArray(data=r, coords={'theta': theta})
+
+    _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    fig = pp.plot(da, ax=ax)
+    assert fig.canvas.xrange == (0, 2 * np.pi)
+
+
+def test_polar_axes_limits_small_range_fits_to_data():
+    # Make some spiral data
+    N = 50
+    r = sc.linspace('theta', 0, 10, N, unit='m')
+    theta = sc.linspace('theta', 0.25 * 2 * np.pi, 0.75 * 2 * np.pi, N, unit='rad')
+    da = sc.DataArray(data=r, coords={'theta': theta})
+
+    _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    fig = pp.plot(da, ax=ax)
+    assert fig.canvas.xmin > 0.0
+    assert fig.canvas.xmax < 2 * np.pi


### PR DESCRIPTION
Fixes #374

The issue was that with padding included, the xmin would go to e.g. -0.5, and the xmax would be above 2pi, which does not play well with the polar axes.
If we clip the limits, it behaves better.

This might be a little surprising if someone would like to explicitly set the range to something like [0, 4pi], as it will silently be clipped to [0, 2pi]... however, does setting it to 4pi even make any sense?
I checked that if a coordinate has a value > 2pi and the limit is set to 2pi, the data point is still plotted on the axes, it is not dropped. So I think this behaviour is ok?