### PR TITLE
Fix unpinned nightly build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,7 @@ commands = pytest {posargs}
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
-  -r requirements/basetest.txt
-  -r requirements/base.in
-  -r requirements/optional.in
+  -r requirements/basetest.in
   plopp
 commands = pytest {posargs}
 


### PR DESCRIPTION
We remove the old `optional.in` file requirement.
Other projects install `basetest.txt`, which is different from `basetest.in` used here.
This is because `basetest.in` also contains our own projects (`scipp`, `mpltoolbox`), and we would like those to stay unpinned.