### PR TITLE
Restore toolbar for tiled plots

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+import warnings
 from typing import Literal
 
 import matplotlib.pyplot as plt
@@ -157,7 +158,9 @@ class Canvas:
         from ipywidgets import VBox
 
         if self.is_widget() and not is_sphinx_build():
-            self.fig.tight_layout()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.fig.tight_layout()
             # The Matplotlib canvas tries to fill the entire width of the output cell,
             # which can add unnecessary whitespace between it and other widgets. To
             # prevent this, we wrap the canvas in a VBox, which seems to help.

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -120,13 +120,13 @@ class Canvas:
         if self.ax is None:
             self.fig = make_figure(figsize=(6.0, 4.0) if figsize is None else figsize)
             self.ax = self.fig.add_subplot()
+            if self.is_widget():
+                self.fig.canvas.toolbar_visible = False
+                self.fig.canvas.header_visible = False
         else:
             self.fig = self.ax.get_figure()
         if aspect is not None:
             self.ax.set_aspect(aspect)
-        if self.is_widget():
-            self.fig.canvas.toolbar_visible = False
-            self.fig.canvas.header_visible = False
 
         if cbar and (self.cax is None):
             if self.ax.name == 'polar':

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -93,6 +93,8 @@ class Tiled:
         new_fig = fig.copy(ax=self.fig.add_subplot(self.gs[inds]))
         self.figures[inds] = new_fig
         self._history.append((inds, new_fig))
+        if is_interactive_backend():
+            self.fig.canvas.toolbar_visible = 'fade-in-fade-out'
 
     def __getitem__(
         self, inds: int | slice | tuple[int, int] | tuple[slice, slice]

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -93,8 +93,6 @@ class Tiled:
         new_fig = fig.copy(ax=self.fig.add_subplot(self.gs[inds]))
         self.figures[inds] = new_fig
         self._history.append((inds, new_fig))
-        if is_interactive_backend():
-            self.fig.canvas.toolbar_visible = 'fade-in-fade-out'
 
     def __getitem__(
         self, inds: int | slice | tuple[int, int] | tuple[slice, slice]


### PR DESCRIPTION
Fixes 2 cases:

1. When making `tiled` plots using the `%matplotlib widget` backend, the toolbar would disappear.

```Py
import plopp as pp
%matplotlib widget

f = pp.data.data1d().plot()
f / f
```

2. Toolbar would also be absent when making figures using custom axes, e.g.:

```Py
import plopp as pp
import matplotlib.pyplot as plt
%matplotlib widget

fig, ax = plt.subplots(2, 1)
f1 = pp.data.data1d().plot(ax=ax[0])
f2 = pp.data.data2d().plot(ax=ax[1])
fig.canvas
```

The fix is to not alter the visibility of the toolbar if axes come from the outside world.

Note that this does mean that if you do something like
```Py
fig, ax = plt.subplots(2, 1)
f = pp.data.data1d().plot(ax=ax[0])
f
```
you will see 'double' toolbar, but usually if one supplies the `ax` argument, it implies that we want to use the matplotlib figure instead of the Plopp figure.