### PR TITLE
Fix showing figures from terminal

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -92,12 +92,3 @@
    plotly
    pythreejs
 ```
-
-## Other
-
-```{eval-rst}
-.. autosummary::
-   :toctree: ../generated
-
-   show
-```

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -37,18 +37,6 @@ from .plotting import (
 del importlib
 
 
-def show() -> None:
-    """
-    A function to display all the currently opened figures (note that this only applies
-    to the figures created via the Matplotlib backend).
-    See https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.show.html for more
-    details.
-    """
-    import matplotlib.pyplot as plt
-
-    plt.show()
-
-
 __all__ = [
     'Camera',
     'Node',
@@ -65,7 +53,6 @@ __all__ = [
     'scatterfigure',
     'scatter3d',
     'scatter3dfigure',
-    'show',
     'show_graph',
     'slicer',
     'superplot',

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -201,12 +201,6 @@ class Canvas:
         """
         self.fig.savefig(filename, **{**{'bbox_inches': 'tight'}, **kwargs})
 
-    def show(self):
-        """
-        Make a call to Matplotlib's underlying ``show`` function.
-        """
-        self.fig.show()
-
     def set_axes(self, dims, units, dtypes):
         """
         Set the axes dimensions and units.

--- a/src/plopp/backends/matplotlib/figure.py
+++ b/src/plopp/backends/matplotlib/figure.py
@@ -97,6 +97,12 @@ class MplBaseFig(BaseFig):
             setattr(out.canvas, prop, getattr(self.canvas, prop))
         return out
 
+    def show(self):
+        """
+        Make a call to Matplotlib's underlying ``show`` function.
+        """
+        self.fig.show()
+
 
 def _make_png_repr(fig):
     return {'image/png': fig_to_bytes(fig, form='png')}

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -27,10 +27,16 @@ def fig_to_bytes(fig: plt.Figure, form: Literal['png', 'svg'] = 'png') -> bytes:
 
 def is_interactive_backend() -> bool:
     """
-    Return ``True`` if the current backend used by Matplotlib is the widget/ipympl
-    backend.
+    Return ``True`` if the current backend used by Matplotlib creates interactive
+    figures. See
+    https://matplotlib.org/stable/users/explain/figure/backends.html#the-builtin-backends
+    for a list of backends.
     """
-    return "inline" not in mpl.get_backend()
+    backend = mpl.get_backend().lower()
+    return any(
+        b in backend
+        for b in ('qt', 'ipympl', 'gtk', 'tk', 'wx', 'nbagg', 'web', 'macosx', 'widget')
+    )
 
 
 def make_figure(*args, **kwargs) -> plt.Figure:
@@ -51,7 +57,10 @@ def make_figure(*args, **kwargs) -> plt.Figure:
     if is_interactive_backend():
         # Create a manager for the figure, which makes it interactive, as well as
         # making it possible to show the figure from the terminal.
-        plt._backend_mod.new_figure_manager_given_figure(1, fig)
+        try:
+            plt._backend_mod.new_figure_manager_given_figure(1, fig)
+        except AttributeError:
+            pass
     return fig
 
 

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -5,10 +5,12 @@ from io import BytesIO
 from typing import Literal
 
 import matplotlib as mpl
-from matplotlib.pyplot import Figure, _get_backend_mod
+
+# from matplotlib.pyplot import Figure, _backend_mod, _get_backend_mod
+import matplotlib.pyplot as plt
 
 
-def fig_to_bytes(fig: Figure, form: Literal['png', 'svg'] = 'png') -> bytes:
+def fig_to_bytes(fig: plt.Figure, form: Literal['png', 'svg'] = 'png') -> bytes:
     """
     Convert a Matplotlib figure to png (default) or svg bytes.
 
@@ -31,10 +33,11 @@ def is_interactive_backend() -> bool:
     backend.
     """
     backend = mpl.get_backend()
-    return any(x in backend for x in ("ipympl", "widget"))
+    # return any(x in backend for x in ("ipympl", "widget"))
+    return "inline" not in backend
 
 
-def make_figure(*args, **kwargs) -> Figure:
+def make_figure(*args, **kwargs) -> plt.Figure:
     """
     Create a new figure.
 
@@ -45,15 +48,21 @@ def make_figure(*args, **kwargs) -> Figure:
     F) directly.
     When using the interactive backend, we need to do more work. The ``plt.Figure``
     will not have a toolbar nor will it be interactive, as opposed to what
-    ``plt.figure`` returns. We therefore copy the minimal required code inside the
-    ``plt.figure`` function which creates a figure manager (which is apparently what
-    creates the toolbar and makes the figure interactive).
+    ``plt.figure`` returns. To fix this, we need to create a manager for the figure
+    (see https://stackoverflow.com/a/75477367).
     """
-    if not is_interactive_backend():
-        return Figure(*args, **kwargs)
-    backend = _get_backend_mod()
-    manager = backend.new_figure_manager(1, *args, FigureClass=Figure, **kwargs)
-    return manager.canvas.figure
+    fig = plt.Figure(*args, **kwargs)
+    if is_interactive_backend():
+        # Create a manager for the figure, which makes it interactive, as well as
+        # making it possible to show the figure from the terminal.
+        plt._backend_mod.new_figure_manager_given_figure(1, fig)
+    return fig
+    # if not is_interactive_backend():
+    #     return fig  # Figure(*args, **kwargs)
+    # # backend = _get_backend_mod()
+    # # manager = backend.new_figure_manager(1, *args, FigureClass=Figure, **kwargs)
+    # else:
+    #     return manager.canvas.figure
 
 
 def make_legend(leg: bool | tuple[float, float] | str) -> dict:

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -35,7 +35,18 @@ def is_interactive_backend() -> bool:
     backend = mpl.get_backend().lower()
     return any(
         b in backend
-        for b in ('qt', 'ipympl', 'gtk', 'tk', 'wx', 'nbagg', 'web', 'macosx', 'widget')
+        for b in (
+            'qt',
+            'ipympl',
+            'gtk',
+            'tk',
+            'wx',
+            'nbagg',
+            'web',
+            'macosx',
+            'widget',
+            'notebook',
+        )
     )
 
 
@@ -57,10 +68,7 @@ def make_figure(*args, **kwargs) -> plt.Figure:
     if is_interactive_backend():
         # Create a manager for the figure, which makes it interactive, as well as
         # making it possible to show the figure from the terminal.
-        try:
-            plt._backend_mod.new_figure_manager_given_figure(1, fig)
-        except AttributeError:
-            pass
+        plt._backend_mod.new_figure_manager_given_figure(1, fig)
     return fig
 
 

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -5,8 +5,6 @@ from io import BytesIO
 from typing import Literal
 
 import matplotlib as mpl
-
-# from matplotlib.pyplot import Figure, _backend_mod, _get_backend_mod
 import matplotlib.pyplot as plt
 
 
@@ -32,9 +30,7 @@ def is_interactive_backend() -> bool:
     Return ``True`` if the current backend used by Matplotlib is the widget/ipympl
     backend.
     """
-    backend = mpl.get_backend()
-    # return any(x in backend for x in ("ipympl", "widget"))
-    return "inline" not in backend
+    return "inline" not in mpl.get_backend()
 
 
 def make_figure(*args, **kwargs) -> plt.Figure:
@@ -57,12 +53,6 @@ def make_figure(*args, **kwargs) -> plt.Figure:
         # making it possible to show the figure from the terminal.
         plt._backend_mod.new_figure_manager_given_figure(1, fig)
     return fig
-    # if not is_interactive_backend():
-    #     return fig  # Figure(*args, **kwargs)
-    # # backend = _get_backend_mod()
-    # # manager = backend.new_figure_manager(1, *args, FigureClass=Figure, **kwargs)
-    # else:
-    #     return manager.canvas.figure
 
 
 def make_legend(leg: bool | tuple[float, float] | str) -> dict:


### PR DESCRIPTION
Fixes #342 

I also removed the top-level `plopp.show()` function which probably did not work and I don't think was ever used.