### PR TITLE
Capture runtime error when hovering over image with unsorted bin edges

### DIFF
--- a/src/plopp/backends/matplotlib/image.py
+++ b/src/plopp/backends/matplotlib/image.py
@@ -227,7 +227,7 @@ class Image:
             if prefix:
                 prefix += ': '
             return prefix + scalar_to_string(val)
-        except IndexError:
+        except (IndexError, RuntimeError):
             return None
 
     def bbox(self, xscale: Literal['linear', 'log'], yscale: Literal['linear', 'log']):


### PR DESCRIPTION
When bin edges are unsorted, we get a different error when hovering, so we need to capture that as well.