### PR TITLE
Make pythreejs a soft dependency

### DIFF
--- a/src/plopp/widgets/clip3d.py
+++ b/src/plopp/widgets/clip3d.py
@@ -8,7 +8,6 @@ from typing import Any, Literal
 
 import ipywidgets as ipw
 import numpy as np
-import pythreejs as p3
 import scipp as sc
 
 from ..core import Node
@@ -79,6 +78,8 @@ class Clip3dTool(ipw.HBox):
         h_axis = 2 if self._direction == 'y' else 1
         width = (self._limits[w_axis][1] - self._limits[w_axis][0]).value
         height = (self._limits[h_axis][1] - self._limits[h_axis][0]).value
+
+        import pythreejs as p3
 
         self.outlines = [
             p3.LineSegments(


### PR DESCRIPTION
When `%matplotlib widget` is enabled, an interactive figure is made and this imports widgets, and there is a top-level import of `pythreejs` in one of the widgets, thus making `pythreejs` a hard dependency.

We fix this here.