### PR TITLE
Fix image plot with log scales

### DIFF
--- a/src/plopp/backends/matplotlib/fast_image.py
+++ b/src/plopp/backends/matplotlib/fast_image.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import numpy as np
 import scipp as sc
-from matplotlib.image import AxesImage
 
 from ...core.utils import coord_as_bin_edges, scalar_to_string
 from ...graphics.bbox import BoundingBox, axis_bounds


### PR DESCRIPTION
Doing
```Py
import plopp as pp

pp.data.data2d().plot(scale={'x': 'log', 'y': 'log'})
```
would yield
```
File [~/miniforge3/lib/python3.12/site-packages/matplotlib/backends/backend_agg.py:70](http://localhost:8888/home/nvaytet/miniforge3/lib/python3.12/site-packages/matplotlib/backends/backend_agg.py#line=69), in RendererAgg.__init__(self, width, height, dpi)
     68 self.width = width
     69 self.height = height
---> 70 self._renderer = _RendererAgg(int(width), int(height), dpi)
     71 self._filter_renderers = []
     73 self._update_methods()

ValueError: Image size of 214242x162587 pixels is too large. It must be less than 2^16 in each direction.
```
when using the static backend in Jupyter (widget backed was ok).

This is apparently  only happens when using the `AxesImage` artist instead of `imshow` in matplotlib.
We had decided to go with `AxesImage` initially because calling `imshow` does a bunch of extra things like automatically setting the aspect ratio of the axes, regardless of what it was before.

Now, we use `imshow`, but make sure to reset the aspect ratio to what was requested by the user.

This is not caught by the tests because it apparently only happens with the jupyter inline backend...

See https://github.com/scipp/plopp/pull/438#issuecomment-2808764160