### PR TITLE
Update deprecation warnings filter in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,10 +81,9 @@ filterwarnings = [
   'ignore:Passing unrecognized arguments to super:DeprecationWarning',
   'ignore:Jupyter is migrating its paths:DeprecationWarning',
   'ignore:setDaemon\(\) is deprecated, set the daemon attribute instead:DeprecationWarning',
-  'ignore:TriCutTool is deprecated::',
-  'ignore:Cut3dTool is deprecated::',
   # Should be removed once https://github.com/plotly/plotly.py/issues/4997 is fixed
   'ignore: \*scattermapbox\* is deprecated:DeprecationWarning',
+  'ignore:There is no current event loop:DeprecationWarning',
 ]
 
 [tool.ruff]


### PR DESCRIPTION
- Fixes #421 
- Also remove some old filters which are from classes that have now been removed.

This is not technically a fix for #421 but at least tests will continue to pass.