### PR TITLE
Fix aspect ratio keyword arg for 1d plots

### DIFF
--- a/src/plopp/plotting/plot.py
+++ b/src/plopp/plotting/plot.py
@@ -85,6 +85,7 @@ def plot(
     """
 
     common_args = {
+        'aspect': aspect,
         'grid': grid,
         'norm': norm,
         'scale': scale,
@@ -119,12 +120,7 @@ def plot(
     elif ndim == 2:
         if len(nodes) > 1:
             raise_multiple_inputs_for_2d_plot_error(origin='plot')
-        return imagefigure(
-            *nodes,
-            aspect=aspect,
-            cbar=cbar,
-            **common_args,
-        )
+        return imagefigure(*nodes, cbar=cbar, **common_args)
     else:
         raise ValueError(
             'The plot function can only plot 1d and 2d data, got input '

--- a/tests/backends/matplotlib/mpl_plot_test.py
+++ b/tests/backends/matplotlib/mpl_plot_test.py
@@ -193,3 +193,12 @@ def test_polar_axes_limits_small_range_fits_to_data():
     fig = pp.plot(da, ax=ax)
     assert fig.canvas.xmin > 0.0
     assert fig.canvas.xmax < 2 * np.pi
+
+
+def test_aspect_ratio():
+    da = data_array(ndim=1)
+    fig = da.plot(aspect='equal')
+    assert fig.canvas.ax.get_aspect() == 1.0
+    da = data_array(ndim=2)
+    fig = da.plot(aspect='equal')
+    assert fig.canvas.ax.get_aspect() == 1.0


### PR DESCRIPTION
```Py
import plopp as pp

pp.data.data1d().plot(aspect='equal')
```
would ignore the `aspect` kwarg before these changes.