### PR TITLE
Drop unused coords

### DIFF
--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -228,8 +228,6 @@ def preprocess(
         _check_size(out)
     if coords is not None:
         renamed_dims = {}
-        if isinstance(coords, str):
-            coords = [coords]
         for dim in coords:
             underlying = out.coords[dim].dims[-1]
             if underlying in renamed_dims:

--- a/tests/plotting/common_test.py
+++ b/tests/plotting/common_test.py
@@ -25,6 +25,14 @@ def test_preprocess_use_non_dimension_coords():
     assert out.coords['yy2'].max() == 3.3 * da.coords['yy'].max()
 
 
+def test_preprocess_use_non_dimension_coord_single_str():
+    da = data_array(ndim=1)
+    da.coords['xx2'] = 7.5 * da.coords['xx']
+    out = preprocess(da, coords='xx2')
+    assert set(out.dims) == {'xx2'}
+    assert out.coords['xx2'].max() == 7.5 * da.coords['xx'].max()
+
+
 def test_preprocess_warns_when_coordinate_is_not_sorted():
     da = data_array(ndim=1)
     unsorted = sc.concat([da['xx', 20:], da['xx', :20]], dim='xx')
@@ -86,3 +94,10 @@ def test_preprocess_drops_coords_that_are_not_plotted_custom_coords():
     da.coords['yy2'] = 3.3 * da.coords['yy']
     out = preprocess(da, coords=['yy2', 'xx'])
     assert set(out.coords) == {'xx', 'yy2'}
+
+
+def test_preprocess_drops_coords_that_are_not_plotted_custom_coord_single_str():
+    da = data_array(ndim=1)
+    da.coords['xx2'] = 7.5 * da.coords['xx']
+    out = preprocess(da, coords='xx')
+    assert set(out.coords) == {'xx'}

--- a/tests/plotting/common_test.py
+++ b/tests/plotting/common_test.py
@@ -40,12 +40,12 @@ def test_preprocess_no_warning_if_dtype_cannot_be_sorted():
         dims=['xx'], values=np.random.random((da.sizes['xx'], 3))
     )
     out = preprocess(da)  # no warning should be emitted
-    assert 'vecs' in out.coords
+    assert 'vecs' not in out.coords  # coord doesn't participate in plot
     da.coords['strings'] = sc.array(
         dims=['xx'], values=list('ba' * (da.sizes['xx'] // 2))
     )
     out = preprocess(da)  # no warning should be emitted
-    assert 'strings' in out.coords
+    assert 'strings' not in out.coords  # coord doesn't participate in plot
 
 
 @pytest.mark.parametrize(
@@ -70,3 +70,19 @@ def test_preprocess_raises_for_unsupported_dtype(dtype_and_shape):
         match=f'The input has dtype {dtype} which is not supported by Plopp',
     ):
         preprocess(v)
+
+
+def test_preprocess_drops_coords_that_are_not_plotted_dim_coords():
+    da = data_array(ndim=2)
+    da.coords['xx2'] = 7.5 * da.coords['xx']
+    da.coords['yy2'] = 3.3 * da.coords['yy']
+    out = preprocess(da)
+    assert set(out.coords) == {'xx', 'yy'}
+
+
+def test_preprocess_drops_coords_that_are_not_plotted_custom_coords():
+    da = data_array(ndim=2)
+    da.coords['xx2'] = 7.5 * da.coords['xx']
+    da.coords['yy2'] = 3.3 * da.coords['yy']
+    out = preprocess(da, coords=['yy2', 'xx'])
+    assert set(out.coords) == {'xx', 'yy2'}

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -414,6 +414,16 @@ def test_plot_1d_datetime_length_1():
     pp.plot(da)
 
 
+def test_plot_1d_extra_datetime_coord_binedges():
+    da = data_array(ndim=1)
+    dim = da.dim
+    size = da.sizes[dim]
+    da.coords['times'] = (sc.arange('t', 2 * size, unit='s') + sc.epoch(unit='s')).fold(
+        dim='t', sizes={dim: size, 't': 2}
+    )
+    pp.plot(da)
+
+
 def test_plot_1d_data_with_errorbars():
     da = data_array(ndim=1, variances=True)
     p = da.plot()


### PR DESCRIPTION
AFAIK, there is no need to keep all coords around. And this caused a problem in Scipp where the averaging introduced in #428 fails for a datetime coord. (See https://github.com/scipp/scipp/pull/3695)