### PR TITLE
Rename the `name` property of a Node to `pretty_name`

### DIFF
--- a/src/plopp/core/graph.py
+++ b/src/plopp/core/graph.py
@@ -23,8 +23,8 @@ def _make_graphviz_digraph(*args, **kwargs):
 def _walk_graph(start, nodes, edges, views, labels):
     label = (
         escape(str(start.func)) + '\nid = ' + start.id
-        if start.name is None
-        else escape(start.name)
+        if start.pretty_name is None
+        else escape(start.pretty_name)
     )
     nodes[start.id] = label
     for child in start.children:

--- a/src/plopp/core/helpers.py
+++ b/src/plopp/core/helpers.py
@@ -38,6 +38,6 @@ def widget_node(widget) -> Node:
         ``ipywidgets`` library, or a custom widget.
     """
     n = Node(func=lambda: widget.value)
-    n.name = f'Widget <{type(widget).__name__}: {type(widget.value).__name__}>'
+    n.pretty_name = f'Widget <{type(widget).__name__}: {type(widget.value).__name__}>'
     widget.observe(n.notify_children, names="value")
     return n

--- a/src/plopp/core/node_class.py
+++ b/src/plopp/core/node_class.py
@@ -64,10 +64,10 @@ class Node:
                 )
             )
             fname = getattr(self.func, "__name__", str(self.func))
-            self.name = f'{fname}({args_string})'
+            self.pretty_name = f'{fname}({args_string})'
         else:
             val_str = f'={func!r}' if isinstance(func, int | float | str) else ""
-            self.name = f'Input <{type(func).__name__}{val_str}>'
+            self.pretty_name = f'Input <{type(func).__name__}{val_str}>'
 
         # Attempt to set children after setting name in case error message is needed
         for parent in chain(self.parents, self.kwparents.values()):
@@ -194,7 +194,7 @@ class Node:
         return self.id == other.id
 
     def __repr__(self) -> str:
-        return f"Node(name={self.name})"
+        return f"Node(name={self.pretty_name})"
 
     def __add__(self, other: Node | Any) -> Node:
         return Node(lambda x, y: x + y, self, other)

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -316,9 +316,9 @@ def input_to_nodes(obj: PlottableMulti, processor: Callable) -> list[Node]:
     nodes = [Node(processor, inp, name=name) for name, inp in to_nodes]
     for node in nodes:
         if hasattr(processor, 'func'):
-            node.name = processor.func.__name__
+            node.pretty_name = processor.func.__name__
         else:
-            node.name = 'Preprocess data'
+            node.pretty_name = 'Preprocess data'
     return nodes
 
 

--- a/src/plopp/widgets/drawing.py
+++ b/src/plopp/widgets/drawing.py
@@ -86,12 +86,12 @@ class DrawingTool(ToggleTool):
 
     def make_node(self, artist):
         draw_node = Node(self._get_artist_info(artist=artist, figure=self._figure))
-        draw_node.name = f'Draw node {len(self._draw_nodes)}'
+        draw_node.pretty_name = f'Draw node {len(self._draw_nodes)}'
         nodeid = draw_node.id
         self._draw_nodes[nodeid] = draw_node
         artist.nodeid = nodeid
         output_node = node(self._func)(self._input_node, draw_node)
-        output_node.name = f'Output node {len(self._output_nodes)}'
+        output_node.pretty_name = f'Output node {len(self._output_nodes)}'
         self._output_nodes[nodeid] = output_node
         if self._destination_is_fig:
             output_node.add_view(self._destination.view)

--- a/src/plopp/widgets/linesave.py
+++ b/src/plopp/widgets/linesave.py
@@ -45,7 +45,7 @@ class LineSaveTool(VBar):
 
         data = self._data_node.request_data()
         node = Node(data)
-        node.name = f'Save node {len(self._lines)}'
+        node.pretty_name = f'Save node {len(self._lines)}'
         line_id = node._id
         node.add_view(self._fig.view)
         self._fig.view.render()

--- a/tests/core/node_test.py
+++ b/tests/core/node_test.py
@@ -213,24 +213,24 @@ def test_node_converts_raw_data_to_Node():
 
 def test_node_names_from_args():
     n = Node(add, 1, 3)
-    assert n.name == 'add(arg_0, arg_1)'
+    assert n.pretty_name == 'add(arg_0, arg_1)'
 
 
 def test_node_names_from_kwargs():
     n = Node(add, x=1, y=3)
-    assert n.name == 'add(x, y)'
+    assert n.pretty_name == 'add(x, y)'
 
 
 def test_node_names_from_args_and_kwargs():
     n = Node(add, 4, y=35)
-    assert n.name == 'add(arg_0, y)'
+    assert n.pretty_name == 'add(arg_0, y)'
 
 
 def test_node_name_from_raw_input():
-    assert Node(5).name == 'Input <int=5>'
-    assert Node(1.2).name == 'Input <float=1.2>'
-    assert Node('hello').name == "Input <str='hello'>"
-    assert Node([1, 2, 3]).name == 'Input <list>'
+    assert Node(5).pretty_name == 'Input <int=5>'
+    assert Node(1.2).pretty_name == 'Input <float=1.2>'
+    assert Node('hello').pretty_name == "Input <str='hello'>"
+    assert Node([1, 2, 3]).pretty_name == 'Input <list>'
 
 
 def test_input_node_value():


### PR DESCRIPTION
This is to avoid clashes with the `.name` property of a `DataArray` which is used in preprocessing the data.
If a node was passed to a plotting function (instead of a DataArray) and had a name, this would be displayed on the colorbar.

Example:
```Py
import plopp as pp

pp.plot(pp.Node(pp.data.data2d()))
```
![Screenshot_20250706_234409](https://github.com/user-attachments/assets/d9dc2ac2-6bf5-4232-ab86-42c11d9eb4b0)
