### PR TITLE
Add player to slicing slider widgets

### DIFF
--- a/docs/plotting/slicer-plot.ipynb
+++ b/docs/plotting/slicer-plot.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fba6798e-6843-4b82-b304-822e2277dfe8",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Animate the sliders\n",
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31a1e511-951e-4d91-a5e1-ef7f8afbb59d",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/plotting/slicer-plot.ipynb
+++ b/docs/plotting/slicer-plot.ipynb
@@ -90,6 +90,19 @@
    "source": [
     "pp.slicer(da, keep=['x', 'y'], enable_player=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Can I have a 3D plot with a slider?\n",
+    "\n",
+    "3D plots are not supported out of the box by the [plopp.slicer](../generated/plopp.slicer.html) function,\n",
+    "but it is still possible to create them.\n",
+    "\n",
+    "An example in the [gallery](../gallery/scatter3d-with-slider.html) shows you how to do this."
+   ]
   }
  ],
  "metadata": {

--- a/docs/plotting/slicer-plot.ipynb
+++ b/docs/plotting/slicer-plot.ipynb
@@ -61,6 +61,35 @@
    "source": [
     "pp.slicer(da, keep=['x'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fba6798e-6843-4b82-b304-822e2277dfe8",
+   "metadata": {},
+   "source": [
+    "## Animate the sliders\n",
+    "\n",
+    "<div class=\"versionadded\" style=\"font-weight: bold;\">\n",
+    "\n",
+    "<img src=\"../_static/circle-exclamation.svg\" width=\"16\" height=\"16\" />\n",
+    "&nbsp;\n",
+    "New in version 25.07.0.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "It is possible to display some animation controls (play button) next to the slider,\n",
+    "by using the `enable_player=True` option:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31a1e511-951e-4d91-a5e1-ef7f8afbb59d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp.slicer(da, keep=['x', 'y'], enable_player=True)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/plotting/slicer-plot.ipynb
+++ b/docs/plotting/slicer-plot.ipynb
@@ -98,10 +98,10 @@
    "source": [
     "## Can I have a 3D plot with a slider?\n",
     "\n",
-    "3D plots are not supported out of the box by the [plopp.slicer](../generated/plopp.slicer.html) function,\n",
+    "3D plots are not supported out of the box by the [plopp.slicer](../generated/plopp.slicer.rst) function,\n",
     "but it is still possible to create them.\n",
     "\n",
-    "An example in the [gallery](../gallery/scatter3d-with-slider.html) shows you how to do this."
+    "An example in the [gallery](../gallery/scatter3d-with-slider.ipynb) shows you how to do this."
    ]
   }
  ],

--- a/docs/plotting/super-plot.ipynb
+++ b/docs/plotting/super-plot.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "tool = p.right_bar[0]\n",
     "b = tool.button\n",
-    "sl = p.bottom_bar[0].controls['y']['slider']\n",
+    "sl = p.bottom_bar[0].controls['y']\n",
     "b.click()\n",
     "sl.value = 20\n",
     "b.click()\n",
@@ -102,8 +102,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -60,6 +60,7 @@ class Slicer:
         vmin: VariableLike | float = None,
         vmax: VariableLike | float = None,
         cbar: bool = True,
+        enable_player: bool = False,
         **kwargs,
     ):
         nodes = input_to_nodes(
@@ -98,7 +99,9 @@ class Slicer:
         from ..widgets import SliceWidget, slice_dims
 
         self.slider = SliceWidget(
-            nodes[0](), dims=[dim for dim in dims if dim not in keep]
+            nodes[0](),
+            dims=[dim for dim in dims if dim not in keep],
+            enable_player=enable_player,
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]
@@ -130,6 +133,7 @@ def slicer(
     vmin: VariableLike | float = None,
     vmax: VariableLike | float = None,
     cbar: bool = True,
+    enable_player: bool = False,
     **kwargs,
 ) -> FigureLike:
     """
@@ -156,6 +160,10 @@ def slicer(
         The maximum value of the y-axis (1d plots) or color range (2d plots).
     cbar:
         Whether to display a colorbar for 2D plots.
+    enable_player:
+        Add a play button to animate the sliders if True. Defaults to False.
+
+        .. versionadded:: 25.07.0
     **kwargs:
         See :py:func:`plopp.plot` for the full list of figure customization arguments.
     """
@@ -167,5 +175,6 @@ def slicer(
         vmax=vmax,
         coords=coords,
         cbar=cbar,
+        enable_player=enable_player,
         **kwargs,
     ).figure

--- a/src/plopp/widgets/slice.py
+++ b/src/plopp/widgets/slice.py
@@ -76,6 +76,17 @@ class DimSlicer(ipw.VBox):
         """
         self.label.value = coord_element_to_string(self.coord[self.dim, change['new']])
 
+    @property
+    def value(self) -> int | tuple[int, int] | None:
+        """
+        The value of the slider.
+        """
+        return self.slider.value
+
+    @value.setter
+    def value(self, value: int | tuple[int, int] | None):
+        self.slider.value = value
+
 
 class _BaseSliceWidget(VBar, ipw.ValueWidget):
     def __init__(

--- a/src/plopp/widgets/slice.py
+++ b/src/plopp/widgets/slice.py
@@ -77,14 +77,14 @@ class DimSlicer(ipw.VBox):
         self.label.value = coord_element_to_string(self.coord[self.dim, change['new']])
 
     @property
-    def value(self) -> int | tuple[int, int] | None:
+    def value(self) -> int | tuple[int, int]:
         """
         The value of the slider.
         """
         return self.slider.value
 
     @value.setter
-    def value(self, value: int | tuple[int, int] | None):
+    def value(self, value: int | tuple[int, int]):
         self.slider.value = value
 
 

--- a/src/plopp/widgets/slice.py
+++ b/src/plopp/widgets/slice.py
@@ -12,74 +12,110 @@ from ..core.utils import coord_element_to_string
 from .box import VBar
 
 
-class _BaseSliceWidget(VBar, ipw.ValueWidget):
-    def __init__(self, da: sc.DataArray, dims: list[str], slider_constr: ipw.Widget):
-        if isinstance(dims, str):
-            dims = [dims]
-        self._slider_dims = dims
-        self.controls = {}
-        self.view = None
-        children = []
-
-        for dim in self._slider_dims:
-            coord = (
-                da.coords[dim]
-                if dim in da.coords
-                else sc.arange(dim, da.sizes[dim], unit=None)
+class DimSlicer(ipw.VBox):
+    def __init__(
+        self,
+        dim: str,
+        size: int,
+        coord: sc.Variable,
+        slider_constr: type[ipw.Widget],
+        enable_player: bool = False,
+    ):
+        if enable_player and not issubclass(slider_constr, ipw.IntSlider):
+            raise TypeError(
+                "Player can only be enabled for IntSlider, not for IntRangeSlider."
             )
-            widget_args = {
-                'step': 1,
-                'description': dim,
-                'min': 0,
-                'max': da.sizes[dim] - 1,
-                'value': (da.sizes[dim] - 1) // 2
-                if slider_constr is ipw.IntSlider
-                else None,
-                'continuous_update': True,
-                'readout': False,
-                'layout': {"width": "200px"},
-                'style': {'description_width': 'initial'},
-            }
-            slider = slider_constr(**widget_args)
-            continuous_update = ipw.Checkbox(
-                value=True,
-                tooltip="Continuous update",
-                indent=False,
-                layout={"width": "20px"},
+        widget_args = {
+            'step': 1,
+            'description': dim,
+            'min': 0,
+            'max': size - 1,
+            'value': (size - 1) // 2 if slider_constr is ipw.IntSlider else None,
+            'continuous_update': True,
+            'readout': False,
+            'layout': {"width": "200px", "margin": "0px 0px 0px 10px"},
+            'style': {'description_width': 'initial'},
+        }
+        self.slider = slider_constr(**widget_args)
+        self.continuous_update = ipw.Checkbox(
+            value=True,
+            tooltip="Continuous update",
+            indent=False,
+            layout={"width": "20px"},
+        )
+        self.label = ipw.Label(
+            value=coord_element_to_string(coord[dim, self.slider.value])
+        )
+        ipw.jslink(
+            (self.continuous_update, 'value'), (self.slider, 'continuous_update')
+        )
+
+        children = [self.slider, self.continuous_update, self.label]
+        if enable_player:
+            self.player = ipw.Play(
+                value=self.slider.value,
+                min=self.slider.min,
+                max=self.slider.max,
+                step=self.slider.step,
+                interval=100,
+                description='Play',
             )
-            label = ipw.Label(value=coord_element_to_string(coord[dim, slider.value]))
-            ipw.jslink((continuous_update, 'value'), (slider, 'continuous_update'))
+            ipw.jslink((self.player, 'value'), (self.slider, 'value'))
+            children.insert(0, self.player)
 
-            self.controls[dim] = {
-                'continuous': continuous_update,
-                'slider': slider,
-                'label': label,
-                'coord': coord,
-            }
-            slider.observe(self._update_label, names='value')
-            slider.observe(self._on_subwidget_change, names='value')
-            children.append(ipw.HBox([continuous_update, slider, label]))
+        self.dim = dim
+        self.coord = coord
+        self.slider.observe(self._update_label, names='value')
 
-        self._on_subwidget_change()
-        super().__init__(children)
+        super().__init__([ipw.HBox(children)])
 
     def _update_label(self, change: dict[str, Any]):
         """
         Update the readout label with the coordinate value, instead of the integer
         readout index.
         """
-        dim = change['owner'].description
-        coord = self.controls[dim]['coord'][dim, change['new']]
-        self.controls[dim]['label'].value = coord_element_to_string(coord)
+        self.label.value = coord_element_to_string(self.coord[self.dim, change['new']])
+
+
+class _BaseSliceWidget(VBar, ipw.ValueWidget):
+    def __init__(
+        self,
+        da: sc.DataArray,
+        dims: list[str],
+        slider_constr: ipw.Widget,
+        enable_player: bool = False,
+    ):
+        if isinstance(dims, str):
+            dims = [dims]
+        self.controls = {}
+        self.view = None
+        children = []
+
+        for dim in dims:
+            coord = (
+                da.coords[dim]
+                if dim in da.coords
+                else sc.arange(dim, da.sizes[dim], unit=None)
+            )
+            self.controls[dim] = DimSlicer(
+                dim=dim,
+                size=da.sizes[dim],
+                coord=coord,
+                slider_constr=slider_constr,
+                enable_player=enable_player,
+            )
+            self.controls[dim].slider.observe(self._on_subwidget_change, names='value')
+            children.append(self.controls[dim])
+
+        self._on_subwidget_change()
+        super().__init__(children)
 
     def _on_subwidget_change(self, _=None):
         """
         Update the value of the widget.
         The value is a dict containing one entry per slider, giving the slider's value.
         """
-        self.value = {
-            dim: self.controls[dim]['slider'].value for dim in self._slider_dims
-        }
+        self.value = {dim: slicer.slider.value for dim, slicer in self.controls.items()}
 
 
 SliceWidget = partial(_BaseSliceWidget, slider_constr=ipw.IntSlider)
@@ -95,6 +131,10 @@ da:
     The input data array.
 dims:
     The dimensions to make sliders for.
+enable_player:
+    Add a play button to animate the slider if True. Defaults to False.
+
+    .. versionadded:: 25.07.0
 """
 
 RangeSliceWidget = partial(_BaseSliceWidget, slider_constr=ipw.IntRangeSlider)

--- a/tests/high_level_test.py
+++ b/tests/high_level_test.py
@@ -122,7 +122,7 @@ class TestHighLevelInteractive:
 
         fig = imagefigure(slice_node)
         Box([fig, sl])
-        sl.controls["zz"]["slider"].value = 10
+        sl.controls["zz"].value = 10
 
     def test_3d_image_slicer_with_connected_side_histograms(self):
         da = data_array(ndim=3)
@@ -139,4 +139,4 @@ class TestHighLevelInteractive:
         fx = linefigure(histx)
         fy = linefigure(histy)
         Box([[fx, fy], fig, sl])
-        sl.controls["zz"]["slider"].value = 10
+        sl.controls["zz"].value = 10

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -15,8 +15,8 @@ class TestSlicer1d:
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx'])
         assert sl.slider.value == {'zz': 14, 'yy': 19}
-        assert sl.slider.controls['yy']['slider'].max == da.sizes['yy'] - 1
-        assert sl.slider.controls['zz']['slider'].max == da.sizes['zz'] - 1
+        assert sl.slider.controls['yy'].slider.max == da.sizes['yy'] - 1
+        assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 19]['zz', 14])
 
     def test_update_keep_one_dim(self):
@@ -24,10 +24,10 @@ class TestSlicer1d:
         sl = Slicer(da, keep=['xx'])
         assert sl.slider.value == {'zz': 14, 'yy': 19}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 19]['zz', 14])
-        sl.slider.controls['yy']['slider'].value = 5
+        sl.slider.controls['yy'].slider.value = 5
         assert sl.slider.value == {'zz': 14, 'yy': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 14])
-        sl.slider.controls['zz']['slider'].value = 8
+        sl.slider.controls['zz'].slider.value = 8
         assert sl.slider.value == {'zz': 8, 'yy': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 8])
 
@@ -35,7 +35,7 @@ class TestSlicer1d:
         ds = dataset(ndim=2)
         sl = Slicer(ds, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy']['slider'].value = 5
+        sl.slider.controls['yy'].slider.value = 5
         assert sc.identical(nodes[0].request_data(), ds['a']['yy', 5])
         assert sc.identical(nodes[1].request_data(), ds['b']['yy', 5])
 
@@ -44,7 +44,7 @@ class TestSlicer1d:
         dg = sc.DataGroup(a=da, b=da * 2.5)
         sl = Slicer(dg, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy']['slider'].value = 5
+        sl.slider.controls['yy'].slider.value = 5
         assert sc.identical(nodes[0].request_data(), dg['a']['yy', 5])
         assert sc.identical(nodes[1].request_data(), dg['b']['yy', 5])
 
@@ -53,7 +53,7 @@ class TestSlicer1d:
         b = data_array(ndim=2) * 2.5
         sl = Slicer({'a': a, 'b': b}, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy']['slider'].value = 5
+        sl.slider.controls['yy'].slider.value = 5
         assert sc.identical(nodes[0].request_data(), a['yy', 5])
         assert sc.identical(nodes[1].request_data(), b['yy', 5])
 
@@ -119,7 +119,7 @@ class TestSlicer2d:
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx', 'yy'])
         assert sl.slider.value == {'zz': 14}
-        assert sl.slider.controls['zz']['slider'].max == da.sizes['zz'] - 1
+        assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
         assert sc.identical(sl.slice_nodes[0].request_data(), da['zz', 14])
 
     def test_update_keep_two_dims(self):
@@ -127,7 +127,7 @@ class TestSlicer2d:
         sl = Slicer(da, keep=['xx', 'yy'])
         assert sl.slider.value == {'zz': 14}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['zz', 14])
-        sl.slider.controls['zz']['slider'].value = 5
+        sl.slider.controls['zz'].slider.value = 5
         assert sl.slider.value == {'zz': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['zz', 5])
 
@@ -150,7 +150,7 @@ class TestSlicer2d:
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z']['slider'].value = 6
+        sl.slider.controls['z'].slider.value = 6
         # Colormapper range fits to the values in the new slice
         assert cm.vmin == 5 * 10 * 6
         assert cm.vmax == 5 * 10 * 7 - 1
@@ -167,7 +167,7 @@ class TestSlicer2d:
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z']['slider'].value = 6
+        sl.slider.controls['z'].slider.value = 6
         # Colormapper range does not change
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -127,7 +127,7 @@ class TestSlicer2d:
         sl = Slicer(da, keep=['xx', 'yy'])
         assert sl.slider.value == {'zz': 14}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['zz', 14])
-        sl.slider.controls['zz'].slider.value = 5
+        sl.slider.controls['zz'].value = 5
         assert sl.slider.value == {'zz': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['zz', 5])
 
@@ -150,7 +150,7 @@ class TestSlicer2d:
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z'].slider.value = 6
+        sl.slider.controls['z'].value = 6
         # Colormapper range fits to the values in the new slice
         assert cm.vmin == 5 * 10 * 6
         assert cm.vmax == 5 * 10 * 7 - 1
@@ -167,7 +167,7 @@ class TestSlicer2d:
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z'].slider.value = 6
+        sl.slider.controls['z'].value = 6
         # Colormapper range does not change
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -24,10 +24,10 @@ class TestSlicer1d:
         sl = Slicer(da, keep=['xx'])
         assert sl.slider.value == {'zz': 14, 'yy': 19}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 19]['zz', 14])
-        sl.slider.controls['yy'].slider.value = 5
+        sl.slider.controls['yy'].value = 5
         assert sl.slider.value == {'zz': 14, 'yy': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 14])
-        sl.slider.controls['zz'].slider.value = 8
+        sl.slider.controls['zz'].value = 8
         assert sl.slider.value == {'zz': 8, 'yy': 5}
         assert sc.identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 8])
 
@@ -35,7 +35,7 @@ class TestSlicer1d:
         ds = dataset(ndim=2)
         sl = Slicer(ds, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].slider.value = 5
+        sl.slider.controls['yy'].value = 5
         assert sc.identical(nodes[0].request_data(), ds['a']['yy', 5])
         assert sc.identical(nodes[1].request_data(), ds['b']['yy', 5])
 
@@ -44,7 +44,7 @@ class TestSlicer1d:
         dg = sc.DataGroup(a=da, b=da * 2.5)
         sl = Slicer(dg, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].slider.value = 5
+        sl.slider.controls['yy'].value = 5
         assert sc.identical(nodes[0].request_data(), dg['a']['yy', 5])
         assert sc.identical(nodes[1].request_data(), dg['b']['yy', 5])
 
@@ -53,7 +53,7 @@ class TestSlicer1d:
         b = data_array(ndim=2) * 2.5
         sl = Slicer({'a': a, 'b': b}, keep=['xx'])
         nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].slider.value = 5
+        sl.slider.controls['yy'].value = 5
         assert sc.identical(nodes[0].request_data(), a['yy', 5])
         assert sc.identical(nodes[1].request_data(), b['yy', 5])
 

--- a/tests/plotting/superplot_test.py
+++ b/tests/plotting/superplot_test.py
@@ -30,12 +30,10 @@ def test_save_line():
     tool.save_line()
     assert len(tool._lines) == 1
     line = list(tool._lines.values())[-1]
-    assert sc.identical(
-        line['line']._data, da['yy', slider.controls['yy']['slider'].value]
-    )
+    assert sc.identical(line['line']._data, da['yy', slider.controls['yy'].value])
     assert len(tool.container.children) == 1
 
-    slider.controls['yy']['slider'].value = 5
+    slider.controls['yy'].value = 5
     tool.save_line()
     assert len(tool._lines) == 2
     line = list(tool._lines.values())[-1]
@@ -50,9 +48,9 @@ def test_remove_line():
     assert len(tool._lines) == 0
     tool.save_line()
     slider = sp.bottom_bar[0]
-    slider.controls['yy']['slider'].value = 5
+    slider.controls['yy'].value = 5
     tool.save_line()
-    slider.controls['yy']['slider'].value = 15
+    slider.controls['yy'].value = 15
     tool.save_line()
     assert len(tool._lines) == 3
     assert len(tool.container.children) == 3

--- a/tests/widgets/slice_test.py
+++ b/tests/widgets/slice_test.py
@@ -24,8 +24,8 @@ def test_slice_creation(widget):
 def test_slice_value_property():
     da = data_array(ndim=3)
     sw = SliceWidget(da, dims=['yy', 'xx'])
-    sw.controls['xx'].slider.value = 10
-    sw.controls['yy'].slider.value = 15
+    sw.controls['xx'].value = 10
+    sw.controls['yy'].value = 15
     assert sw.value == {'xx': 10, 'yy': 15}
 
 
@@ -34,13 +34,13 @@ def test_slice_label_updates():
     da.coords['xx'] *= 1.1
     da.coords['yy'] *= 3.3
     sw = SliceWidget(da, dims=['yy', 'xx'])
-    sw.controls['xx'].slider.value = 0
-    sw.controls['yy'].slider.value = 0
+    sw.controls['xx'].value = 0
+    sw.controls['yy'].value = 0
     assert sw.controls['xx'].label.value == '0.0 [m]'
-    sw.controls['xx'].slider.value = 10
+    sw.controls['xx'].value = 10
     assert sw.controls['xx'].label.value == '11.0 [m]'
     assert sw.controls['yy'].label.value == '0.0 [m]'
-    sw.controls['yy'].slider.value = 15
+    sw.controls['yy'].value = 15
     assert sw.controls['yy'].label.value == '49.5 [m]'
 
 

--- a/tests/widgets/slice_test.py
+++ b/tests/widgets/slice_test.py
@@ -12,20 +12,20 @@ from plopp.widgets import RangeSliceWidget, SliceWidget, slice_dims
 def test_slice_creation(widget):
     da = data_array(ndim=3)
     sw = widget(da, dims=['yy', 'xx'])
-    assert sw._slider_dims == ['yy', 'xx']
-    assert sw.controls['xx']['slider'].min == 0
-    assert sw.controls['xx']['slider'].max == da.sizes['xx'] - 1
-    assert sw.controls['xx']['slider'].description == 'xx'
-    assert sw.controls['yy']['slider'].min == 0
-    assert sw.controls['yy']['slider'].max == da.sizes['yy'] - 1
-    assert sw.controls['yy']['slider'].description == 'yy'
+    assert set(sw.controls.keys()) == {'yy', 'xx'}
+    assert sw.controls['xx'].slider.min == 0
+    assert sw.controls['xx'].slider.max == da.sizes['xx'] - 1
+    assert sw.controls['xx'].slider.description == 'xx'
+    assert sw.controls['yy'].slider.min == 0
+    assert sw.controls['yy'].slider.max == da.sizes['yy'] - 1
+    assert sw.controls['yy'].slider.description == 'yy'
 
 
 def test_slice_value_property():
     da = data_array(ndim=3)
     sw = SliceWidget(da, dims=['yy', 'xx'])
-    sw.controls['xx']['slider'].value = 10
-    sw.controls['yy']['slider'].value = 15
+    sw.controls['xx'].slider.value = 10
+    sw.controls['yy'].slider.value = 15
     assert sw.value == {'xx': 10, 'yy': 15}
 
 
@@ -34,14 +34,20 @@ def test_slice_label_updates():
     da.coords['xx'] *= 1.1
     da.coords['yy'] *= 3.3
     sw = SliceWidget(da, dims=['yy', 'xx'])
-    sw.controls['xx']['slider'].value = 0
-    sw.controls['yy']['slider'].value = 0
-    assert sw.controls['xx']['label'].value == '0.0 [m]'
-    sw.controls['xx']['slider'].value = 10
-    assert sw.controls['xx']['label'].value == '11.0 [m]'
-    assert sw.controls['yy']['label'].value == '0.0 [m]'
-    sw.controls['yy']['slider'].value = 15
-    assert sw.controls['yy']['label'].value == '49.5 [m]'
+    sw.controls['xx'].slider.value = 0
+    sw.controls['yy'].slider.value = 0
+    assert sw.controls['xx'].label.value == '0.0 [m]'
+    sw.controls['xx'].slider.value = 10
+    assert sw.controls['xx'].label.value == '11.0 [m]'
+    assert sw.controls['yy'].label.value == '0.0 [m]'
+    sw.controls['yy'].slider.value = 15
+    assert sw.controls['yy'].label.value == '49.5 [m]'
+
+
+def test_make_slice_widget_with_player():
+    da = data_array(ndim=3)
+    sw = SliceWidget(da, dims=['zz'], enable_player=True)
+    assert sw.controls['zz'].player is not None
 
 
 def test_slice_dims():


### PR DESCRIPTION
Example:
```Py
import plopp as pp

da = pp.data.data3d()
pp.slicer(da, keep=['x', 'y'], enable_player=True)
```
![Screenshot_20250707_161139](https://github.com/user-attachments/assets/d2c290f8-0e48-4312-a6e4-df1bd985387b)

Fixes #462 

Note that I decided to disable it for `RangeSlider` because it would really complicate things, especially when the looping is enabled, then the max would temporarily become the min, etc...