### PR TITLE
Better tiled

### DIFF
--- a/src/plopp/backends/matplotlib/figure.py
+++ b/src/plopp/backends/matplotlib/figure.py
@@ -62,16 +62,6 @@ class MplBaseFig(BaseFig):
         """
         return self.view.canvas.save(filename, **kwargs)
 
-    def __add__(self, other):
-        from .tiled import hstack
-
-        return hstack(self, other)
-
-    def __truediv__(self, other):
-        from .tiled import vstack
-
-        return vstack(self, other)
-
     def copy(self, ax: Axes | None = None) -> MplBaseFig:
         """
         Create a copy of the figure.
@@ -155,6 +145,16 @@ class InteractiveFigure(MplBaseFig, VBox):
             self.bottom_bar,
         ]
 
+    def __add__(self, other):
+        from ...widgets import HBar
+
+        return HBar([self, other])
+
+    def __truediv__(self, other):
+        from ...widgets import VBar
+
+        return VBar([self, other])
+
 
 class StaticFigure(MplBaseFig):
     """
@@ -186,6 +186,16 @@ class StaticFigure(MplBaseFig):
         Convert the Matplotlib figure to an image widget.
         """
         return self.view.canvas.to_image()
+
+    def __add__(self, other):
+        from .tiled import hstack
+
+        return hstack(self, other)
+
+    def __truediv__(self, other):
+        from .tiled import vstack
+
+        return vstack(self, other)
 
 
 def Figure(*args, **kwargs):

--- a/src/plopp/backends/matplotlib/tiled.py
+++ b/src/plopp/backends/matplotlib/tiled.py
@@ -68,6 +68,8 @@ class Tiled:
         nrows: int,
         ncols: int,
         figsize: tuple[float, float] | None = None,
+        hspace: float = 0.05,
+        wspace: float = 0.1,
         **kwargs: Any,
     ) -> None:
         self.nrows = nrows
@@ -81,7 +83,9 @@ class Tiled:
             layout='constrained',
         )
 
-        self.gs = gridspec.GridSpec(nrows, ncols, figure=self.fig, **kwargs)
+        self.gs = gridspec.GridSpec(
+            nrows, ncols, figure=self.fig, wspace=wspace, hspace=hspace, **kwargs
+        )
         self.figures = np.full((nrows, ncols), None)
         self._history = []
 

--- a/src/plopp/widgets/box.py
+++ b/src/plopp/widgets/box.py
@@ -26,12 +26,6 @@ class Bar:
         children.remove(obj)
         self.children = children
 
-    def __add__(self, other):
-        return HBox([self, other])
-
-    def __truediv__(self, other):
-        return VBox([self, other])
-
 
 class VBar(VBox, Bar):
     """
@@ -44,6 +38,12 @@ class VBar(VBox, Bar):
         elif isinstance(ind, slice):
             return VBar(self.children[ind])
 
+    def __add__(self, other):
+        return HBar([self, other])
+
+    def __truediv__(self, other):
+        return VBar([self, other])
+
 
 class HBar(HBox, Bar):
     """
@@ -55,6 +55,12 @@ class HBar(HBox, Bar):
             return self.children[ind]
         elif isinstance(ind, slice):
             return HBar(self.children[ind])
+
+    def __add__(self, other):
+        return HBar([self, other])
+
+    def __truediv__(self, other):
+        return VBar([self, other])
 
 
 class Box(VBar):

--- a/src/plopp/widgets/box.py
+++ b/src/plopp/widgets/box.py
@@ -26,6 +26,12 @@ class Bar:
         children.remove(obj)
         self.children = children
 
+    def __add__(self, other):
+        return HBox([self, other])
+
+    def __truediv__(self, other):
+        return VBox([self, other])
+
 
 class VBar(VBox, Bar):
     """

--- a/tests/widgets/box_test.py
+++ b/tests/widgets/box_test.py
@@ -88,3 +88,39 @@ def test_bar_length(Bar):
     b3 = ipw.Button(description='Button 3')
     bar = Bar([b1, b2, b3])
     assert len(bar) == 3
+
+
+def test_add_hbars():
+    b1 = HBar([ipw.Button(description='Button 1')])
+    b2 = HBar([ipw.Button(description='Button 2')])
+    bar = b1 + b2
+    assert isinstance(bar, HBar)
+    assert len(bar.children) == 2
+    assert bar.children[0] is b1
+    assert bar.children[1] is b2
+
+
+def test_divide_hbars():
+    b1 = HBar([ipw.Button(description='Button 1')])
+    b2 = HBar([ipw.Button(description='Button 2')])
+    bar = b1 / b2
+    assert isinstance(bar, VBar)
+    assert len(bar.children) == 2
+    assert bar.children[0] is b1
+    assert bar.children[1] is b2
+
+
+def test_mix_add_divide_bars():
+    b1 = HBar([ipw.Button(description='Button 1')])
+    b2 = HBar([ipw.Button(description='Button 2')])
+    b3 = VBar([ipw.Button(description='Button 3')])
+    b4 = VBar([ipw.Button(description='Button 4')])
+    bar = (b1 + b2) / (b3 + b4)
+    assert isinstance(bar, VBar)
+    assert len(bar.children) == 2
+    assert isinstance(bar.children[0], HBar)
+    assert isinstance(bar.children[1], HBar)
+    assert bar.children[0].children[0] is b1
+    assert bar.children[0].children[1] is b2
+    assert bar.children[1].children[0] is b3
+    assert bar.children[1].children[1] is b4


### PR DESCRIPTION
Before:
<img width="1228" height="396" alt="Screenshot_20250903_202540" src="https://github.com/user-attachments/assets/ba9478bd-0ec8-4131-8034-58f1622e920d" />

After:
<img width="1228" height="396" alt="Screenshot_20250903_202431" src="https://github.com/user-attachments/assets/8f3362d1-1123-4edd-acbf-a60b523c7a3d" />

We also just use `ipywidgets` to make tiled figures of interactive figs when `%matplotlib widget` is enabled.