### PR TITLE
Fix scatter3d so it handles updates to positions

### DIFF
--- a/src/plopp/backends/pythreejs/scatter3d.py
+++ b/src/plopp/backends/pythreejs/scatter3d.py
@@ -192,9 +192,7 @@ class Scatter3d:
             New data to update the point cloud values from.
         """
         check_ndim(new_values, ndim=1, origin='Scatter3d')
-        need_new_point_cloud = False
-        if self._data.shape != new_values.shape:
-            need_new_point_cloud = True
+        need_new_point_cloud = self._data.shape != new_values.shape
 
         self._data = new_values
 

--- a/src/plopp/backends/pythreejs/scatter3d.py
+++ b/src/plopp/backends/pythreejs/scatter3d.py
@@ -189,13 +189,14 @@ class Scatter3d:
         ):
             return
         self._backup_coords()
-        self.geometry.attributes["position"].array = np.array(
+        self.geometry.attributes["position"].array = np.stack(
             [
                 self._data.coords[self._x].values.astype('float32'),
                 self._data.coords[self._y].values.astype('float32'),
                 self._data.coords[self._z].values.astype('float32'),
-            ]
-        ).T
+            ],
+            axis=1,
+        )
 
     def update(self, new_values):
         """

--- a/src/plopp/backends/pythreejs/scatter3d.py
+++ b/src/plopp/backends/pythreejs/scatter3d.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
-import time
 import uuid
 from typing import Literal
 
@@ -210,8 +208,8 @@ class Scatter3d:
             self._new_positions = self._update_positions()
 
         # First call to finalize: this will be the final call if there is no
-        # colormapper. If there is a colormapper, it will call finalize again once it has
-        # updated the colors.
+        # colormapper. If there is a colormapper, it will call finalize again once it
+        # has updated the colors.
         self._finalize_update(1)
 
     def _finalize_update(self, count: int) -> None:

--- a/src/plopp/backends/pythreejs/scatter3d.py
+++ b/src/plopp/backends/pythreejs/scatter3d.py
@@ -135,6 +135,7 @@ class Scatter3d:
             size=2.5 * self._size * pixel_ratio,
             transparent=True,
             opacity=self._opacity,
+            depthTest=self._opacity > 0.5,
         )
         return p3.Points(geometry=geometry, material=material)
 
@@ -215,14 +216,17 @@ class Scatter3d:
             if self._new_points is not None:
                 self._canvas.remove(self.points)
                 self.points = self._new_points
-                self._new_points = None
-                self._canvas.add(self.points)
             if self._new_positions is not None:
                 self.position = self._new_positions
                 self._new_positions = None
             if self._new_colors is not None:
                 self.color = self._new_colors
                 self._new_colors = None
+            # For some reason, adding the points to the scene before updating the colors
+            # still shows the old colors for a brief moment, even if hold() is active.
+            if self._new_points is not None:
+                self._new_points = None
+                self._canvas.add(self.points)
 
     @property
     def position(self) -> np.ndarray:
@@ -265,10 +269,11 @@ class Scatter3d:
         """
         The scatter points opacity.
         """
-        return self.material.opacity
+        return self._opacity
 
     @opacity.setter
     def opacity(self, val: float):
+        self._opacity = val
         self.material.opacity = val
         self.material.depthTest = val > 0.5
 

--- a/src/plopp/backends/pythreejs/scatter3d.py
+++ b/src/plopp/backends/pythreejs/scatter3d.py
@@ -86,12 +86,12 @@ class Scatter3d:
                     dtype=float, unit=self._data.coords[x].unit
                 ).value
 
-        self.points = None
+        # self.points = None
         self._make_point_cloud()
 
         if self._colormapper is not None:
             self._colormapper.add_artist(self.uid, self)
-            self._update_colors()
+            # self._update_colors()
         else:
             colors = np.broadcast_to(
                 np.array(to_rgb(f'C{artist_number}' if color is None else color)),
@@ -99,7 +99,8 @@ class Scatter3d:
             ).astype('float32')
             self.geometry.attributes["color"].array = colors
 
-        self._add_point_cloud_to_scene()
+        # self._add_point_cloud_to_scene()
+        self._canvas.add(self.points)
 
     def _make_point_cloud(self) -> None:
         """
@@ -107,8 +108,8 @@ class Scatter3d:
         """
         import pythreejs as p3
 
-        if self.points is not None:
-            self._canvas.remove(self.points)
+        # if self.points is not None:
+        #     self._canvas.remove(self.points)
 
         self._backup_coords()
 
@@ -153,11 +154,11 @@ class Scatter3d:
             self._z: self._data.coords[self._z],
         }
 
-    def _add_point_cloud_to_scene(self) -> None:
-        """
-        Add the point cloud to the canvas scene.
-        """
-        self._canvas.add(self.points)
+    # def _add_point_cloud_to_scene(self) -> None:
+    #     """
+    #     Add the point cloud to the canvas scene.
+    #     """
+    #     self._canvas.add(self.points)
 
     def notify_artist(self, message: str) -> None:
         """
@@ -175,6 +176,9 @@ class Scatter3d:
         """
         Set the point cloud's rgba colors:
         """
+        import time
+
+        print('updating colors', time.time())
         self.geometry.attributes["color"].array = self._colormapper.rgba(self.data)[
             ..., :3
         ].astype('float32')
@@ -213,15 +217,20 @@ class Scatter3d:
         self._data = new_values
 
         if need_new_point_cloud:
+            old_points = self.points
             self._make_point_cloud()
         else:
             self._update_positions()
 
-        if self._colormapper is not None:
-            self._update_colors()
+        # if self._colormapper is not None:
+        #     self._update_colors()
 
         if need_new_point_cloud:
-            self._add_point_cloud_to_scene()
+            # We delay adding the points to the scene until after updating the colors
+            # so that we avoid first adding empty points to the scene, and then
+            # performing a color update, which can cause visible flickering.
+            self._canvas.remove(old_points)
+            self._canvas.add(self.points)
 
     @property
     def opacity(self) -> float:

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -220,6 +220,8 @@ class GraphicalView(View):
 
         if self._autoscale:
             self.fit_to_data()
+        elif self.colormapper is not None:
+            self.colormapper.notify_artists()
 
         self.canvas.draw()
 

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -125,11 +125,11 @@ def scatter3d(
         camera=camera,
         **kwargs,
     )
-    clip_planes = ClippingPlanes(fig)
-    fig.toolbar['cut3d'] = ToggleTool(
-        callback=clip_planes.toggle_visibility,
-        icon='layer-group',
-        tooltip='Hide/show spatial cutting tool',
-    )
-    fig.bottom_bar.add(clip_planes)
+    # clip_planes = ClippingPlanes(fig)
+    # fig.toolbar['cut3d'] = ToggleTool(
+    #     callback=clip_planes.toggle_visibility,
+    #     icon='layer-group',
+    #     tooltip='Hide/show spatial cutting tool',
+    # )
+    # fig.bottom_bar.add(clip_planes)
     return fig

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -125,11 +125,11 @@ def scatter3d(
         camera=camera,
         **kwargs,
     )
-    # clip_planes = ClippingPlanes(fig)
-    # fig.toolbar['cut3d'] = ToggleTool(
-    #     callback=clip_planes.toggle_visibility,
-    #     icon='layer-group',
-    #     tooltip='Hide/show spatial cutting tool',
-    # )
-    # fig.bottom_bar.add(clip_planes)
+    clip_planes = ClippingPlanes(fig)
+    fig.toolbar['cut3d'] = ToggleTool(
+        callback=clip_planes.toggle_visibility,
+        icon='layer-group',
+        tooltip='Hide/show spatial cutting tool',
+    )
+    fig.bottom_bar.add(clip_planes)
     return fig

--- a/tests/backends/pythreejs/pythreejs_scatter3d_test.py
+++ b/tests/backends/pythreejs/pythreejs_scatter3d_test.py
@@ -124,3 +124,30 @@ def test_update_raises_when_data_is_not_1d():
         sc.DimensionError, match='Scatter3d only accepts data with 1 dimension'
     ):
         scat.update(da2d)
+
+
+def test_update_with_new_points():
+    da = scatter(npoints=500)
+    scat = Scatter3d(canvas=Canvas(), data=da, x='x', y='y', z='z')
+    assert scat.points.geometry.attributes['position'].array.shape[0] == 500
+    assert scat.points.geometry.attributes['color'].array.shape[0] == 500
+    new = scatter(npoints=200)
+    scat.update(new)
+    assert scat.points.geometry.attributes['position'].array.shape[0] == 200
+    assert scat.points.geometry.attributes['color'].array.shape[0] == 200
+    assert sc.identical(scat._data, new)
+
+
+def test_update_with_new_points_skip_position_update():
+    da = scatter(npoints=500)
+    scat = Scatter3d(
+        canvas=Canvas(), data=da, x='x', y='y', z='z', disable_position_update=True
+    )
+    assert scat.points.geometry.attributes['position'].array.shape[0] == 500
+    assert scat.points.geometry.attributes['color'].array.shape[0] == 500
+    new = scatter(npoints=200)
+    scat.update(new)
+    # This results in points with weird colors so the final state is bad, but it does
+    # not crash, and is evidence that the position update was skipped.
+    assert scat.points.geometry.attributes['position'].array.shape[0] == 500
+    assert scat.points.geometry.attributes['color'].array.shape[0] == 500

--- a/tests/backends/pythreejs/pythreejs_scatter3d_test.py
+++ b/tests/backends/pythreejs/pythreejs_scatter3d_test.py
@@ -126,7 +126,7 @@ def test_update_raises_when_data_is_not_1d():
         scat.update(da2d)
 
 
-def test_update_with_new_points():
+def test_update_with_different_number_of_points():
     da = scatter(npoints=500)
     scat = Scatter3d(canvas=Canvas(), data=da, x='x', y='y', z='z')
     assert scat.points.geometry.attributes['position'].array.shape[0] == 500
@@ -136,18 +136,3 @@ def test_update_with_new_points():
     assert scat.points.geometry.attributes['position'].array.shape[0] == 200
     assert scat.points.geometry.attributes['color'].array.shape[0] == 200
     assert sc.identical(scat._data, new)
-
-
-def test_update_with_new_points_skip_position_update():
-    da = scatter(npoints=500)
-    scat = Scatter3d(
-        canvas=Canvas(), data=da, x='x', y='y', z='z', disable_position_update=True
-    )
-    assert scat.points.geometry.attributes['position'].array.shape[0] == 500
-    assert scat.points.geometry.attributes['color'].array.shape[0] == 500
-    new = scatter(npoints=200)
-    scat.update(new)
-    # This results in points with weird colors so the final state is bad, but it does
-    # not crash, and is evidence that the position update was skipped.
-    assert scat.points.geometry.attributes['position'].array.shape[0] == 500
-    assert scat.points.geometry.attributes['color'].array.shape[0] == 500


### PR DESCRIPTION
Like the 2d scatter plots, the 3d scatter plot will now handle updates to the data that have a different number of points.

If this is the case, we have to remove the point cloud and add a new one to the scene.