### PR TITLE
New arguments for customizing plots

### DIFF
--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -119,12 +119,12 @@ class Canvas:
         if user_vmin is not None:
             if ymin is not None:
                 raise ValueError('Cannot specify both "user_vmin" and "ymin".')
-            deprecated_argument('user_vmin', 'ymin')
+            deprecated_argument(old='user_vmin', new='ymin')
             ymin = user_vmin
         if user_vmax is not None:
             if ymax is not None:
                 raise ValueError('Cannot specify both "user_vmax" and "ymax".')
-            deprecated_argument('user_vmax', 'ymax')
+            deprecated_argument(old='user_vmax', new='ymax')
             ymax = user_vmax
 
         self.fig = None

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -137,8 +137,8 @@ class Canvas:
         self._xmax = xmax
         self._ymin = ymin
         self._ymax = ymax
-        # self._xlabel = xlabel
-        # self._ylabel = ylabel
+        self._xlabel = xlabel
+        self._ylabel = ylabel
         self.units = {}
         self.dims = {}
         self._legend = legend

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -135,6 +135,8 @@ class Canvas:
         self._xmax = xmax
         self._ymin = ymin
         self._ymax = ymax
+        self._xlabel = xlabel
+        self._ylabel = ylabel
         self.units = {}
         self.dims = {}
         self._legend = legend

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -104,6 +104,7 @@ class Canvas:
         logy: bool = False,
         xlabel: str | None = None,
         ylabel: str | None = None,
+        norm: Literal['linear', 'log', None] = None,
         **ignored,
     ):
         # Note on the `**ignored`` keyword arguments: the figure which owns the canvas
@@ -123,6 +124,10 @@ class Canvas:
             if ymax is not None:
                 raise ValueError('Cannot specify both "user_vmax" and "ymax".')
             ymax = user_vmax
+        if norm is not None:
+            if logy:
+                raise ValueError('Cannot specify both "norm" and "logy".')
+            logy = norm == 'log'
 
         self.fig = None
         self.ax = ax

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -12,7 +12,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ...core.utils import maybe_variable_to_number, scalar_to_string
 from ...graphics.bbox import BoundingBox
-from ...utils import deprecated_argument
 from .utils import fig_to_bytes, is_sphinx_build, make_figure, make_legend
 
 
@@ -119,12 +118,10 @@ class Canvas:
         if user_vmin is not None:
             if ymin is not None:
                 raise ValueError('Cannot specify both "user_vmin" and "ymin".')
-            deprecated_argument(old='user_vmin', new='ymin')
             ymin = user_vmin
         if user_vmax is not None:
             if ymax is not None:
                 raise ValueError('Cannot specify both "user_vmax" and "ymax".')
-            deprecated_argument(old='user_vmax', new='ymax')
             ymax = user_vmax
 
         self.fig = None

--- a/src/plopp/backends/matplotlib/canvas.py
+++ b/src/plopp/backends/matplotlib/canvas.py
@@ -137,8 +137,8 @@ class Canvas:
         self._xmax = xmax
         self._ymin = ymin
         self._ymax = ymax
-        self._xlabel = xlabel
-        self._ylabel = ylabel
+        # self._xlabel = xlabel
+        # self._ylabel = ylabel
         self.units = {}
         self.dims = {}
         self._legend = legend

--- a/src/plopp/backends/plotly/canvas.py
+++ b/src/plopp/backends/plotly/canvas.py
@@ -96,8 +96,8 @@ class Canvas:
         self._xmax = xmax
         self._ymin = ymin
         self._ymax = ymax
-        # self._xlabel = xlabel
-        # self._ylabel = ylabel
+        self._xlabel = xlabel
+        self._ylabel = ylabel
         self.units = {}
         self.dims = {}
         self._own_axes = False

--- a/src/plopp/backends/pythreejs/canvas.py
+++ b/src/plopp/backends/pythreejs/canvas.py
@@ -47,6 +47,10 @@ class Canvas:
         self.xscale = 'linear'
         self.yscale = 'linear'
         self.zscale = 'linear'
+        # TODO: Support setting labels on axes via xlabel, ylabel, zlabel args.
+        self._xlabel = None
+        self._ylabel = None
+        self._zlabel = None
         self.outline = None
         self.axticks = None
         self.figsize = np.asarray(figsize if figsize is not None else (600, 400))

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -103,13 +103,24 @@ class ColorMapper:
     mask_cmap:
         The name of the colormap for masked data.
     norm:
-        The colorscale normalization.
+        The colorscale normalization. This is an old parameter name.
+        Prefer using ``logc`` instead.
     vmin:
         The minimum value for the colorscale range. If a number (without a unit) is
         supplied, it is assumed that the unit is the same as the data unit.
+        This is an old parameter name. Prefer using ``cmin`` instead.
     vmax:
         The maximum value for the colorscale range. If a number (without a unit) is
         supplied, it is assumed that the unit is the same as the data unit.
+        This is an old parameter name. Prefer using ``cmax`` instead.
+    cmin:
+        The minimum value for the colorscale range. If a number (without a unit) is
+        supplied, it is assumed that the unit is the same as the data unit.
+    cmax:
+        The maximum value for the colorscale range. If a number (without a unit) is
+        supplied, it is assumed that the unit is the same as the data unit.
+    logc:
+        If ``True``, use a logarithmic colorscale.
     nan_color:
         The color used for representing NAN values.
     figsize:

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -372,3 +372,17 @@ class ColorMapper:
         self.autoscale()
         if self._canvas is not None:
             self._canvas.draw()
+
+    @property
+    def norm(self) -> Literal['linear', 'log']:
+        """
+        Get or set the colorscale normalization.
+        """
+        return 'log' if self._logc else 'linear'
+
+    @norm.setter
+    def norm(self, norm: Literal['linear', 'log']):
+        if norm not in ['linear', 'log']:
+            raise ValueError('norm must be either "linear" or "log".')
+        if norm != self.norm:
+            self.toggle_norm()

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -252,7 +252,7 @@ class ColorMapper:
         # Synchronize the underlying normalizer limits to the current state.
         # Note that the order matters here, as for a normalizer cmin cannot be set above
         # the current cmax.
-        if self._cmin >= self.normalizer.cmax:
+        if self._cmin >= self.normalizer.vmax:
             self.normalizer.vmax = self._cmax
             self.normalizer.vmin = self._cmin
         else:
@@ -328,10 +328,10 @@ class ColorMapper:
     @unit.setter
     def unit(self, unit: str | None):
         self._unit = unit
-        if self.user_vmin is not None:
-            self.user_vmin = maybe_variable_to_number(self.user_vmin, unit=self._unit)
-        if self.user_vmax is not None:
-            self.user_vmax = maybe_variable_to_number(self.user_vmax, unit=self._unit)
+        if self.user_cmin is not None:
+            self.user_cmin = maybe_variable_to_number(self.user_cmin, unit=self._unit)
+        if self.user_cmax is not None:
+            self.user_cmax = maybe_variable_to_number(self.user_cmax, unit=self._unit)
 
     @property
     def clabel(self) -> str | None:

--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -15,7 +15,6 @@ from matplotlib.colors import Colormap, LinearSegmentedColormap, LogNorm, Normal
 from ..backends.matplotlib.utils import fig_to_bytes
 from ..core.limits import find_limits, fix_empty_range
 from ..core.utils import maybe_variable_to_number, merge_masks
-from ..utils import deprecated_argument, deprecated_attribute
 
 
 def _shift_color(color: float, delta: float) -> float:
@@ -136,17 +135,14 @@ class ColorMapper:
         if vmin is not None:
             if cmin is not None:
                 raise ValueError('Cannot specify both "vmin" and "cmin".')
-            deprecated_argument(old='vmin', new='cmin')
             cmin = vmin
         if vmax is not None:
             if cmax is not None:
                 raise ValueError('Cannot specify both "vmax" and "cmax".')
-            deprecated_argument(old='vmax', new='cmax')
             cmax = vmax
         if norm is not None:
             if logc:
                 raise ValueError('Cannot specify both "norm" and "logc".')
-            deprecated_argument(old='norm', new='logc')
             logc = norm == 'log'
 
         self._canvas = canvas
@@ -157,6 +153,7 @@ class ColorMapper:
         self.user_cmax = cmax
         self._cmin = np.inf
         self._cmax = -np.inf
+        self._clabel = clabel
         self._logc = logc
         self.set_colors_on_update = True
 
@@ -178,6 +175,8 @@ class ColorMapper:
                 self.cax = fig.add_axes([0.05, 0.02, 0.2, 0.98])
             self.colorbar = ColorbarBase(self.cax, cmap=self.cmap, norm=self.normalizer)
             self.cax.yaxis.set_label_coords(-0.9, 0.5)
+            if clabel is not None:
+                self.cax.set_ylabel(clabel)
 
     def add_artist(self, key: str, artist: Any):
         self.artists[key] = artist
@@ -275,30 +274,24 @@ class ColorMapper:
     def vmin(self) -> float:
         """
         Get or set the minimum value of the colorbar.
-
-        .. deprecated:: 25.10.0
+        This is an old property name. Prefer using ``cmin`` instead.
         """
-        deprecated_attribute(old='vmin', new='cmin')
         return self.cmin
 
     @vmin.setter
     def vmin(self, vmin: sc.Variable | float):
-        deprecated_attribute(old='vmin', new='cmin')
         self.cmin = vmin
 
     @property
     def vmax(self) -> float:
         """
         Get or set the maximum value of the colorbar.
-
-        .. deprecated:: 25.10.0
+        This is an old property name. Prefer using ``cmax`` instead.
         """
-        deprecated_attribute(old='vmax', new='cmax')
         return self.cmax
 
     @vmax.setter
     def vmax(self, vmax: sc.Variable | float):
-        deprecated_attribute(old='vmax', new='cmax')
         self.cmax = vmax
 
     @property
@@ -357,15 +350,12 @@ class ColorMapper:
     def ylabel(self) -> str | None:
         """
         Get or set the label of the colorbar axis.
-
-        .. deprecated:: 25.10.0
+        This is an old property name. Prefer using ``clabel`` instead.
         """
-        deprecated_attribute(old='ylabel', new='clabel')
         return self.clabel
 
     @ylabel.setter
     def ylabel(self, lab: str):
-        deprecated_attribute(old='ylabel', new='clabel')
         self.clabel = lab
 
     def toggle_norm(self):

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -177,11 +177,6 @@ class GraphicalView(View):
             for i, direction in enumerate(self._dims):
                 if self._dims[direction] is None:
                     self._dims[direction] = new_values.dims[i]
-                if self._dims[direction] not in new_values.dims:
-                    raise KeyError(
-                        "Supplied data is incompatible with this view: "
-                        f"dimension '{self._dims[direction]}' was not found in data."
-                    )
                 if self._dims[direction] not in new_values.coords:
                     raise KeyError(
                         "Supplied data is incompatible with this view: "

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -64,9 +64,26 @@ class GraphicalView(View):
         autoscale: bool = True,
         ax: Any = None,
         cax: Any = None,
+        xmin: sc.Variable | float | None = None,
+        xmax: sc.Variable | float | None = None,
+        ymin: sc.Variable | float | None = None,
+        ymax: sc.Variable | float | None = None,
+        zmin: sc.Variable | float | None = None,
+        zmax: sc.Variable | float | None = None,
+        cmin: sc.Variable | float | None = None,
+        cmax: sc.Variable | float | None = None,
+        logx: bool = False,
+        logy: bool = False,
+        logz: bool = False,
+        logc: bool = False,
+        xlabel: str | None = None,
+        ylabel: str | None = None,
+        zlabel: str | None = None,
+        clabel: str | None = None,
         **kwargs,
     ):
         super().__init__(*nodes)
+
         self._dims = dims
         self._scale = {} if scale is None else scale
         self.artists = {}
@@ -88,6 +105,18 @@ class GraphicalView(View):
             camera=camera,
             ax=ax,
             cax=cax,
+            xmin=xmin,
+            xmax=xmax,
+            ymin=ymin,
+            ymax=ymax,
+            zmin=zmin,
+            zmax=zmax,
+            logx=logx,
+            logy=logy,
+            logz=logz,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            zlabel=zlabel,
         )
 
         if colormapper:
@@ -98,6 +127,10 @@ class GraphicalView(View):
                 norm=norm,
                 vmin=vmin,
                 vmax=vmax,
+                cmin=cmin,
+                cmax=cmax,
+                clabel=clabel,
+                logc=logc,
                 canvas=self.canvas,
                 figsize=getattr(self.canvas, "figsize", None),
             )
@@ -109,8 +142,8 @@ class GraphicalView(View):
         else:
             self.colormapper = None
 
-        if len(self._dims) == 1:
-            self.canvas.yscale = norm
+        # if len(self._dims) == 1:
+        #     self.canvas.yscale = norm
         self.render()
 
     def autoscale(self):

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -191,6 +191,8 @@ class GraphicalView(View):
                 axes_units = {k: coord.unit for k, coord in coords.items()}
                 axes_dtypes = {k: coord.dtype for k, coord in coords.items()}
 
+                data_label = name_with_unit(var=new_values.data, name=self._data_name)
+
                 if set(self._dims) == {'x'}:
                     axes_units['data'] = new_values.unit
                     axes_dtypes['data'] = new_values.dtype
@@ -199,8 +201,16 @@ class GraphicalView(View):
                     axes_units['data'] = new_values.unit
                     axes_dtypes['data'] = new_values.dtype
                     self._data_axis = self.colormapper
+                    if self.colormapper._clabel is None:
+                        # If the private member `_clabel` is None, the user did not
+                        # supply a label, so we set it here based on the data.
+                        self.colormapper.clabel = data_label
                 else:
-                    self._data_axis = self.canvas
+                    # self._data_axis = self.canvas
+                    if self.canvas._ylabel is None:
+                        # If the private member `_ylabel` is None, the user did not
+                        # supply a label, so we set it here based on the data.
+                        self.canvas.ylabel = data_label
 
                 self.canvas.set_axes(
                     dims=self._dims, units=axes_units, dtypes=axes_dtypes
@@ -215,10 +225,10 @@ class GraphicalView(View):
                     if dim in self._scale:
                         setattr(self.canvas, f'{xyz}scale', self._scale[dim])
 
-                if self._data_axis is not None:
-                    self._data_axis.ylabel = name_with_unit(
-                        var=new_values.data, name=self._data_name
-                    )
+                # if self._data_axis is not None:
+                # self._data_axis.ylabel = name_with_unit(
+                #     var=new_values.data, name=self._data_name
+                # )
 
             else:
                 for xy, dim in self._dims.items():
@@ -231,9 +241,15 @@ class GraphicalView(View):
                     )
                     if self._data_name and (new_values.name != self._data_name):
                         self._data_name = None
-                        self._data_axis.ylabel = name_with_unit(
-                            var=sc.scalar(0.0, unit=self.canvas.units['data']), name=''
+                        data_label = name_with_unit(
+                            var=sc.scalar(0.0, unit=self.canvas.units['data']),
+                            name='',
                         )
+                        if self.colormapper is not None:
+                            if self.colormapper._clabel is None:
+                                self.colormapper.clabel = data_label
+                        elif self.canvas._ylabel is None:
+                            self.canvas.ylabel = data_label
 
             if key not in self.artists:
                 self.artists[key] = self._artist_maker(

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -217,11 +217,14 @@ class GraphicalView(View):
                 )
 
                 for xyz, dim in self._dims.items():
-                    setattr(
-                        self.canvas,
-                        f'{xyz}label',
-                        name_with_unit(var=coords[xyz], name=dim),
-                    )
+                    if getattr(self.canvas, f'_{xyz}label') is None:
+                        # If the private member `_{xyz}label` is None, the user did not
+                        # supply a label, so we set it here based on the data.
+                        setattr(
+                            self.canvas,
+                            f'{xyz}label',
+                            name_with_unit(var=coords[xyz], name=dim),
+                        )
                     if dim in self._scale:
                         setattr(self.canvas, f'{xyz}scale', self._scale[dim])
 

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -50,7 +50,7 @@ class GraphicalView(View):
         cmap: str = 'viridis',
         mask_cmap: str = 'gray',
         cbar: bool = False,
-        norm: Literal['linear', 'log'] = 'linear',
+        norm: Literal['linear', 'log', None] = None,
         vmin: sc.Variable | float | None = None,
         vmax: sc.Variable | float | None = None,
         scale: dict[str, str] | None = None,
@@ -117,6 +117,7 @@ class GraphicalView(View):
             xlabel=xlabel,
             ylabel=ylabel,
             zlabel=zlabel,
+            norm=norm if len(dims) == 1 else None,
         )
 
         if colormapper:
@@ -142,8 +143,6 @@ class GraphicalView(View):
         else:
             self.colormapper = None
 
-        # if len(self._dims) == 1:
-        #     self.canvas.yscale = norm
         self.render()
 
     def autoscale(self):

--- a/src/plopp/graphics/graphicalview.py
+++ b/src/plopp/graphics/graphicalview.py
@@ -177,13 +177,17 @@ class GraphicalView(View):
             for i, direction in enumerate(self._dims):
                 if self._dims[direction] is None:
                     self._dims[direction] = new_values.dims[i]
-                try:
-                    coords[direction] = new_values.coords[self._dims[direction]]
-                except KeyError as e:
+                if self._dims[direction] not in new_values.dims:
+                    raise KeyError(
+                        "Supplied data is incompatible with this view: "
+                        f"dimension '{self._dims[direction]}' was not found in data."
+                    )
+                if self._dims[direction] not in new_values.coords:
                     raise KeyError(
                         "Supplied data is incompatible with this view: "
                         f"coordinate '{self._dims[direction]}' was not found in data."
-                    ) from e
+                    )
+                coords[direction] = new_values.coords[self._dims[direction]]
 
             if self.canvas.empty:
                 self._data_name = new_values.name

--- a/src/plopp/plotting/mesh3d.py
+++ b/src/plopp/plotting/mesh3d.py
@@ -44,12 +44,15 @@ def mesh3d(
     vertexcolors: Plottable | None = None,
     edgecolor: str | None = None,
     figsize: tuple[int, int] = (600, 400),
-    norm: Literal['linear', 'log'] = 'linear',
+    logc: bool = False,
     title: str | None = None,
-    vmin: sc.Variable | float = None,
-    vmax: sc.Variable | float = None,
+    cmin: sc.Variable | float = None,
+    cmax: sc.Variable | float = None,
     cmap: str = 'viridis',
     camera: Camera | None = None,
+    norm: Literal['linear', 'log'] = 'linear',
+    vmin: sc.Variable | float = None,
+    vmax: sc.Variable | float = None,
     **kwargs,
 ) -> FigureLike:
     """
@@ -70,18 +73,28 @@ def mesh3d(
         The color of the edges. If None, no edges are drawn.
     figsize:
         The size of the figure.
-    norm:
-        The normalization of the colormap.
+    logc:
+        Set to ``True`` for a logarithmic colorscale.
     title:
         The title of the figure.
-    vmin:
-        The minimum value of the colormap.
-    vmax:
-        The maximum value of the colormap.
+    cmin:
+        Lower bound for the colorscale.
+    cmax:
+        Upper bound for the colorscale.
     cmap:
         The colormap to use.
     camera:
         The camera configuration.
+    norm:
+        The normalization of the colormap (legacy, prefer ``logc`` instead).
+    title:
+        The title of the figure.
+    vmin:
+        The minimum value of the colormap (legacy, prefer ``cmin`` instead).
+    vmax:
+        The maximum value of the colormap (legacy, prefer ``cmax`` instead).
+    **kwargs:
+        Additional keyword arguments are passed to the underlying plotting library.
     """
     from ..graphics import mesh3dfigure
 
@@ -97,12 +110,15 @@ def mesh3d(
         vertexcolors=vertexcolors,
         edgecolor=edgecolor,
         figsize=figsize,
-        norm=norm,
+        logc=logc,
         title=title,
-        vmin=vmin,
-        vmax=vmax,
+        cmin=cmin,
+        cmax=cmax,
         cmap=cmap,
         camera=camera,
+        norm=norm,
+        vmin=vmin,
+        vmax=vmax,
         **kwargs,
     )
     return fig

--- a/src/plopp/plotting/plot.py
+++ b/src/plopp/plotting/plot.py
@@ -82,6 +82,30 @@ def plot(
     legend:
         Show legend if ``True``. If ``legend`` is a tuple, it should contain the
         ``(x, y)`` coordinates of the legend's anchor point in axes coordinates.
+    xmin:
+        Lower limit for x-axis.
+    xmax:
+        Upper limit for x-axis.
+    ymin:
+        Lower limit for y-axis.
+    ymax:
+        Upper limit for y-axis.
+    cmin:
+        Lower limit for colorscale (2d plots only).
+    cmax:
+        Upper limit for colorscale (2d plots only).
+    logx:
+        If ``True``, use logarithmic scale for x-axis.
+    logy:
+        If ``True``, use logarithmic scale for y-axis.
+    logc:
+        If ``True``, use logarithmic scale for colorscale (2d plots only).
+    xlabel:
+        Label for x-axis.
+    ylabel:
+        Label for y-axis.
+    clabel:
+        Label for colorscale (2d plots only).
     **kwargs:
         All other kwargs are directly forwarded to Matplotlib, the underlying plotting
         library. The underlying functions called are the following:

--- a/src/plopp/plotting/plot.py
+++ b/src/plopp/plotting/plot.py
@@ -28,6 +28,18 @@ def plot(
     vmin: Variable | float | None = None,
     vmax: Variable | float | None = None,
     legend: bool | tuple[float, float] = True,
+    xmin: Variable | float | None = None,
+    xmax: Variable | float | None = None,
+    ymin: Variable | float | None = None,
+    ymax: Variable | float | None = None,
+    cmin: Variable | float | None = None,
+    cmax: Variable | float | None = None,
+    logx: bool = False,
+    logy: bool = False,
+    logc: bool = False,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    clabel: str | None = None,
     **kwargs,
 ) -> FigureLike:
     """Plot a Scipp object.
@@ -93,6 +105,14 @@ def plot(
         'vmin': vmin,
         'vmax': vmax,
         'figsize': figsize,
+        'xlabel': xlabel,
+        'ylabel': ylabel,
+        'xmin': xmin,
+        'xmax': xmax,
+        'ymin': ymin,
+        'ymax': ymax,
+        'logx': logx,
+        'logy': logy,
         **kwargs,
     }
 
@@ -120,7 +140,15 @@ def plot(
     elif ndim == 2:
         if len(nodes) > 1:
             raise_multiple_inputs_for_2d_plot_error(origin='plot')
-        return imagefigure(*nodes, cbar=cbar, **common_args)
+        return imagefigure(
+            *nodes,
+            cbar=cbar,
+            cmin=cmin,
+            cmax=cmax,
+            clabel=clabel,
+            logc=logc,
+            **common_args,
+        )
     else:
         raise ValueError(
             'The plot function can only plot 1d and 2d data, got input '

--- a/src/plopp/plotting/plot.py
+++ b/src/plopp/plotting/plot.py
@@ -22,7 +22,7 @@ def plot(
     grid: bool = False,
     ignore_size: bool = False,
     mask_color: str = 'black',
-    norm: Literal['linear', 'log'] = 'linear',
+    norm: Literal['linear', 'log', None] = None,
     scale: dict[str, str] | None = None,
     title: str | None = None,
     vmin: Variable | float | None = None,

--- a/src/plopp/plotting/scatter.py
+++ b/src/plopp/plotting/scatter.py
@@ -40,7 +40,7 @@ def scatter(
     y: str = 'y',
     size: str | float | None = None,
     figsize: tuple[float, float] | None = None,
-    norm: Literal['linear', 'log'] = 'linear',
+    norm: Literal['linear', 'log', None] = None,
     title: str | None = None,
     vmin: sc.Variable | float = None,
     vmax: sc.Variable | float = None,

--- a/src/plopp/plotting/scatter.py
+++ b/src/plopp/plotting/scatter.py
@@ -40,13 +40,16 @@ def scatter(
     y: str = 'y',
     size: str | float | None = None,
     figsize: tuple[float, float] | None = None,
-    norm: Literal['linear', 'log', None] = None,
+    logc: bool = False,
     title: str | None = None,
-    vmin: sc.Variable | float = None,
-    vmax: sc.Variable | float = None,
+    cmin: sc.Variable | float = None,
+    cmax: sc.Variable | float = None,
     cbar: bool = False,
     cmap: str = 'viridis',
     legend: bool | tuple[float, float] = True,
+    norm: Literal['linear', 'log', None] = None,
+    vmin: sc.Variable | float = None,
+    vmax: sc.Variable | float = None,
     **kwargs,
 ) -> FigureLike:
     """
@@ -68,14 +71,14 @@ def scatter(
         be used for the size of the markers.
     figsize:
         The width and height of the figure, in inches.
-    norm:
-        Set to ``'log'`` for a logarithmic colorscale (only applicable if ``cbar`` is
+    logc:
+        Set to ``True`` for a logarithmic colorscale (only applicable if ``cbar`` is
         ``True``).
     title:
         The figure title.
-    vmin:
+    cmin:
         Lower bound for the colorscale for (only applicable if ``cbar`` is ``True``).
-    vmax:
+    cmax:
         Upper bound for the colorscale for (only applicable if ``cbar`` is ``True``).
     cbar:
         Show colorbar if ``True``. If ``cbar`` is ``True``, the marker will be colored
@@ -85,6 +88,15 @@ def scatter(
     legend:
         Show legend if ``True``. If ``legend`` is a tuple, it should contain the
         ``(x, y)`` coordinates of the legend's anchor point in axes coordinates.
+    norm:
+        Set to ``'log'`` for a logarithmic colorscale (only applicable if ``cbar`` is
+        ``True``, legacy, prefer ``logc`` instead).
+    vmin:
+        Lower bound for the colorscale for (only applicable if ``cbar`` is ``True``,
+        legacy, prefer ``cmin`` instead).
+    vmax:
+        Upper bound for the colorscale for (only applicable if ``cbar`` is ``True``,
+        legacy, prefer ``cmax`` instead).
     **kwargs:
         All other kwargs are forwarded the underlying plotting library.
     """
@@ -100,12 +112,15 @@ def scatter(
         y=y,
         size=size,
         figsize=figsize,
-        norm=norm,
+        logc=logc,
         title=title,
-        vmin=vmin,
-        vmax=vmax,
+        cmin=cmin,
+        cmax=cmax,
         cmap=cmap,
         cbar=cbar,
         legend=legend,
+        norm=norm,
+        vmin=vmin,
+        vmax=vmax,
         **kwargs,
     )

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -44,13 +44,16 @@ def scatter3d(
     z: str = 'z',
     pos: str | None = None,
     figsize: tuple[int, int] = (600, 400),
-    norm: Literal['linear', 'log', None] = None,
+    logc: bool = False,
     title: str | None = None,
-    vmin: sc.Variable | float = None,
-    vmax: sc.Variable | float = None,
+    cmin: sc.Variable | float = None,
+    cmax: sc.Variable | float = None,
     cbar: bool = False,
     cmap: str = 'viridis',
     camera: Camera | None = None,
+    norm: Literal['linear', 'log', None] = None,
+    vmin: sc.Variable | float = None,
+    vmax: sc.Variable | float = None,
     **kwargs,
 ) -> FigureLike:
     """Make a three-dimensional scatter plot.
@@ -76,20 +79,28 @@ def scatter3d(
         The name of the coordinate that is to be used for the Z positions.
     pos:
         The name of the vector coordinate that is to be used for the positions.
-    norm:
-        Set to ``'log'`` for a logarithmic colorscale.
     figsize:
         The size of the 3d rendering area, in pixels: ``(width, height)``.
+    logc:
+        Set to ``True`` for a logarithmic colorscale.
     title:
         The figure title.
-    vmin:
+    cmin:
         Lower bound for the colorscale.
-    vmax:
+    cmax:
         Upper bound for the colorscale.
     cmap:
         The name of the colormap.
     camera:
         Initial camera configuration (position, target).
+    norm:
+        Set to ``'log'`` for a logarithmic colorscale (legacy, prefer ``logc`` instead).
+    vmin:
+        Lower bound for the colorscale (legacy, prefer ``cmin`` instead).
+    vmax:
+        Upper bound for the colorscale (legacy, prefer ``cmax`` instead).
+    **kwargs:
+        All other kwargs are forwarded the underlying plotting library.
 
     Returns
     -------
@@ -116,13 +127,16 @@ def scatter3d(
         y=y,
         z=z,
         figsize=figsize,
-        norm=norm,
+        logc=logc,
         title=title,
-        vmin=vmin,
-        vmax=vmax,
+        cmin=cmin,
+        cmax=cmax,
         cmap=cmap,
         cbar=cbar,
         camera=camera,
+        norm=norm,
+        vmin=vmin,
+        vmax=vmax,
         **kwargs,
     )
     clip_planes = ClippingPlanes(fig)

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -44,7 +44,7 @@ def scatter3d(
     z: str = 'z',
     pos: str | None = None,
     figsize: tuple[int, int] = (600, 400),
-    norm: Literal['linear', 'log'] = 'linear',
+    norm: Literal['linear', 'log', None] = None,
     title: str | None = None,
     vmin: sc.Variable | float = None,
     vmax: sc.Variable | float = None,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -41,10 +41,6 @@ class Slicer:
         of higher dimensional inputs.
     coords:
         If supplied, use these coords instead of the input's dimension coordinates.
-    vmin:
-        The minimum value of the y-axis (1d plots) or color range (2d plots).
-    vmax:
-        The maximum value of the y-axis (1d plots) or color range (2d plots).
     cbar:
         Whether to display a colorbar for 2D plots.
     **kwargs:
@@ -57,8 +53,6 @@ class Slicer:
         *,
         keep: list[str] | None = None,
         coords: list[str] | None = None,
-        # vmin: VariableLike | float = None,
-        # vmax: VariableLike | float = None,
         cbar: bool = True,
         enable_player: bool = False,
         **kwargs,
@@ -131,8 +125,6 @@ def slicer(
     keep: list[str] | None = None,
     autoscale: bool = True,
     coords: list[str] | None = None,
-    # vmin: VariableLike | float = None,
-    # vmax: VariableLike | float = None,
     cbar: bool = True,
     enable_player: bool = False,
     **kwargs,
@@ -155,10 +147,6 @@ def slicer(
         every time the data changes if ``True``.
     coords:
         If supplied, use these coords instead of the input's dimension coordinates.
-    vmin:
-        The minimum value of the y-axis (1d plots) or color range (2d plots).
-    vmax:
-        The maximum value of the y-axis (1d plots) or color range (2d plots).
     cbar:
         Whether to display a colorbar for 2D plots.
     enable_player:
@@ -172,8 +160,6 @@ def slicer(
         obj,
         keep=keep,
         autoscale=autoscale,
-        # vmin=vmin,
-        # vmax=vmax,
         coords=coords,
         cbar=cbar,
         enable_player=enable_player,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -57,8 +57,8 @@ class Slicer:
         *,
         keep: list[str] | None = None,
         coords: list[str] | None = None,
-        vmin: VariableLike | float = None,
-        vmax: VariableLike | float = None,
+        # vmin: VariableLike | float = None,
+        # vmax: VariableLike | float = None,
         cbar: bool = True,
         enable_player: bool = False,
         **kwargs,
@@ -119,7 +119,8 @@ class Slicer:
                 f'but {ndims} were requested.'
             )
 
-        self.figure = make_figure(*self.slice_nodes, vmin=vmin, vmax=vmax, **kwargs)
+        # self.figure = make_figure(*self.slice_nodes, vmin=vmin, vmax=vmax, **kwargs)
+        self.figure = make_figure(*self.slice_nodes, **kwargs)
         require_interactive_figure(self.figure, 'slicer')
         self.figure.bottom_bar.add(self.slider)
 
@@ -130,8 +131,8 @@ def slicer(
     keep: list[str] | None = None,
     autoscale: bool = True,
     coords: list[str] | None = None,
-    vmin: VariableLike | float = None,
-    vmax: VariableLike | float = None,
+    # vmin: VariableLike | float = None,
+    # vmax: VariableLike | float = None,
     cbar: bool = True,
     enable_player: bool = False,
     **kwargs,
@@ -171,8 +172,8 @@ def slicer(
         obj,
         keep=keep,
         autoscale=autoscale,
-        vmin=vmin,
-        vmax=vmax,
+        # vmin=vmin,
+        # vmax=vmax,
         coords=coords,
         cbar=cbar,
         enable_player=enable_player,

--- a/src/plopp/utils.py
+++ b/src/plopp/utils.py
@@ -33,4 +33,13 @@ def deprecated_argument(old: str, new: str) -> None:
     )
 
 
-__all__ = ['deprecated', 'deprecated_argument']
+def deprecated_attribute(old: str, new: str) -> None:
+    warnings.warn(
+        f'Attribute "{old}" is deprecated and will be removed in a future release. '
+        f'Please use "{new}" instead.',
+        VisibleDeprecationWarning,
+        stacklevel=2,
+    )
+
+
+__all__ = ['deprecated', 'deprecated_argument', 'deprecated_attribute']

--- a/src/plopp/utils.py
+++ b/src/plopp/utils.py
@@ -24,22 +24,4 @@ def deprecated(message: str = '') -> Callable:
     return decorator
 
 
-def deprecated_argument(old: str, new: str) -> None:
-    warnings.warn(
-        f'Argument "{old}" is deprecated and will be removed in a future release. '
-        f'Please use "{new}" instead.',
-        VisibleDeprecationWarning,
-        stacklevel=2,
-    )
-
-
-def deprecated_attribute(old: str, new: str) -> None:
-    warnings.warn(
-        f'Attribute "{old}" is deprecated and will be removed in a future release. '
-        f'Please use "{new}" instead.',
-        VisibleDeprecationWarning,
-        stacklevel=2,
-    )
-
-
-__all__ = ['deprecated', 'deprecated_argument', 'deprecated_attribute']
+__all__ = ['deprecated']

--- a/src/plopp/utils.py
+++ b/src/plopp/utils.py
@@ -24,4 +24,13 @@ def deprecated(message: str = '') -> Callable:
     return decorator
 
 
-__all__ = ['deprecated']
+def deprecated_argument(old: str, new: str) -> None:
+    warnings.warn(
+        f'Argument "{old}" is deprecated and will be removed in a future release. '
+        f'Please use "{new}" instead.',
+        VisibleDeprecationWarning,
+        stacklevel=2,
+    )
+
+
+__all__ = ['deprecated', 'deprecated_argument']

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -596,3 +596,53 @@ def test_can_plot_dict_with_non_string_keys():
 def test_plot_bool_with_no_range():
     x = sc.zeros(sizes={'x': 10}, dtype='bool')
     _ = x.plot()
+
+
+def test_xmin():
+    da = data_array(ndim=1)
+    fig = da.plot(xmin=sc.scalar(2.5, unit='m'))
+    assert fig.canvas.xmin == 2.5
+
+
+def test_xmax():
+    da = data_array(ndim=1)
+    fig = da.plot(xmax=sc.scalar(7.5, unit='m'))
+    assert fig.canvas.xmax == 7.5
+
+
+def test_ymin():
+    da = data_array(ndim=1)
+    fig = da.plot(ymin=sc.scalar(-0.5, unit='m/s'))
+    assert fig.canvas.ymin == -0.5
+
+
+def test_ymax():
+    da = data_array(ndim=1)
+    fig = da.plot(ymax=sc.scalar(0.68, unit='m/s'))
+    assert fig.canvas.ymax == 0.68
+
+
+def test_logx():
+    da = data_array(ndim=1)
+    fig = da.plot(logx=True)
+    assert fig.canvas.xscale == 'log'
+    assert fig.canvas.yscale == 'linear'
+
+
+def test_logy():
+    da = data_array(ndim=1)
+    fig = da.plot(logy=True)
+    assert fig.canvas.yscale == 'log'
+    assert fig.canvas.xscale == 'linear'
+
+
+def test_xlabel():
+    da = data_array(ndim=1)
+    fig = da.plot(xlabel='MyXLabel')
+    assert fig.canvas.xlabel == 'MyXLabel'
+
+
+def test_ylabel():
+    da = data_array(ndim=1)
+    fig = da.plot(ylabel='MyYLabel')
+    assert fig.canvas.ylabel == 'MyYLabel'

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -604,10 +604,22 @@ def test_xmin():
     assert fig.canvas.xmin == 2.5
 
 
+def test_xmin_no_unit():
+    da = data_array(ndim=1)
+    fig = da.plot(xmin=3.3)
+    assert fig.canvas.xmin == 3.3
+
+
 def test_xmax():
     da = data_array(ndim=1)
     fig = da.plot(xmax=sc.scalar(7.5, unit='m'))
     assert fig.canvas.xmax == 7.5
+
+
+def test_xmax_no_unit():
+    da = data_array(ndim=1)
+    fig = da.plot(xmax=8.1)
+    assert fig.canvas.xmax == 8.1
 
 
 def test_ymin():
@@ -616,9 +628,21 @@ def test_ymin():
     assert fig.canvas.ymin == -0.5
 
 
+def test_ymin_no_unit():
+    da = data_array(ndim=1)
+    fig = da.plot(ymin=-0.5)
+    assert fig.canvas.ymin == -0.5
+
+
 def test_ymax():
     da = data_array(ndim=1)
     fig = da.plot(ymax=sc.scalar(0.68, unit='m/s'))
+    assert fig.canvas.ymax == 0.68
+
+
+def test_ymax_no_unit():
+    da = data_array(ndim=1)
+    fig = da.plot(ymax=0.68)
     assert fig.canvas.ymax == 0.68
 
 

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -339,12 +339,6 @@ def test_2d_plot_does_not_accept_data_with_other_dimensionality_on_update():
         sc.DimensionError, match='Image only accepts data with 2 dimension'
     ):
         fig.update(new=data_array(ndim=3))
-    # The data dim has been renamed
-    with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
-        fig.update(new=data_array(ndim=2).rename_dims(yy='newy'))
-    # The data dim and coord has been renamed
-    with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
-        fig.update(new=data_array(ndim=2).rename(yy='newy'))
 
 
 def test_figure_has_data_name_on_colorbar_for_one_image():

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -297,7 +297,7 @@ def test_axis_label_with_transposed_2d_coord():
 
 def test_plot_1d_data_over_2d_data():
     f = data_array(ndim=2).plot()
-    data_array(ndim=1).plot(ax=f.ax)
+    data_array(ndim=2).plot(ax=f.ax)
 
 
 def test_plot_1d_data_over_2d_data_datetime():
@@ -333,7 +333,7 @@ def test_2d_plot_does_not_accept_data_with_other_dimensionality_on_update():
     fig = da.plot()
     # The data has no 'y' coordinate
     with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
-        fig.update(new=data_array(ndim=1))
+        fig.update(new=data_array(ndim=2))
     # The data has 3 dimensions
     with pytest.raises(
         sc.DimensionError, match='Image only accepts data with 2 dimension'
@@ -389,3 +389,77 @@ def test_plot_2d_all_values_masked():
 def test_plot_bool_with_no_range():
     x = sc.zeros(sizes={'x': 10, 'y': 10}, dtype='bool')
     _ = x.plot()
+
+
+def test_xmin():
+    da = data_array(ndim=2)
+    fig = da.plot(xmin=sc.scalar(2.5, unit='m'))
+    assert fig.canvas.xmin == 2.5
+
+
+def test_xmax():
+    da = data_array(ndim=2)
+    fig = da.plot(xmax=sc.scalar(7.5, unit='m'))
+    assert fig.canvas.xmax == 7.5
+
+
+def test_ymin():
+    da = data_array(ndim=2)
+    fig = da.plot(ymin=sc.scalar(-0.5, unit='m/s'))
+    assert fig.canvas.ymin == -0.5
+
+
+def test_ymax():
+    da = data_array(ndim=2)
+    fig = da.plot(ymax=sc.scalar(0.68, unit='m/s'))
+    assert fig.canvas.ymax == 0.68
+
+
+def test_cmin():
+    da = data_array(ndim=2)
+    fig = da.plot(cmin=sc.scalar(2.5, unit='m/s'))
+    assert fig.view.colormapper.cmin == 2.5
+
+
+def test_cmax():
+    da = data_array(ndim=2)
+    fig = da.plot(cmax=sc.scalar(7.5, unit='m/s'))
+    assert fig.view.colormapper.cmax == 7.5
+
+
+def test_logx():
+    da = data_array(ndim=2)
+    fig = da.plot(logx=True)
+    assert fig.canvas.xscale == 'log'
+    assert fig.canvas.yscale == 'linear'
+
+
+def test_logy():
+    da = data_array(ndim=2)
+    fig = da.plot(logy=True)
+    assert fig.canvas.yscale == 'log'
+    assert fig.canvas.xscale == 'linear'
+
+
+def test_logc():
+    da = data_array(ndim=2)
+    fig = da.plot(logc=True)
+    assert fig.view.colormapper.norm == 'log'
+
+
+def test_xlabel():
+    da = data_array(ndim=2)
+    fig = da.plot(xlabel='MyXLabel')
+    assert fig.canvas.xlabel == 'MyXLabel'
+
+
+def test_ylabel():
+    da = data_array(ndim=2)
+    fig = da.plot(ylabel='MyYLabel')
+    assert fig.canvas.ylabel == 'MyYLabel'
+
+
+def test_clabel():
+    da = data_array(ndim=2)
+    fig = da.plot(clabel='MyColorLabel')
+    assert fig.colormapper.clabel == 'MyColorLabel'

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -333,12 +333,18 @@ def test_2d_plot_does_not_accept_data_with_other_dimensionality_on_update():
     fig = da.plot()
     # The data has no 'y' coordinate
     with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
-        fig.update(new=data_array(ndim=2))
+        fig.update(new=data_array(ndim=1))
     # The data has 3 dimensions
     with pytest.raises(
         sc.DimensionError, match='Image only accepts data with 2 dimension'
     ):
         fig.update(new=data_array(ndim=3))
+    # The data dim has been renamed
+    with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
+        fig.update(new=data_array(ndim=2).rename_dims(yy='newy'))
+    # The data dim and coord has been renamed
+    with pytest.raises(KeyError, match='Supplied data is incompatible with this view'):
+        fig.update(new=data_array(ndim=2).rename(yy='newy'))
 
 
 def test_figure_has_data_name_on_colorbar_for_one_image():
@@ -397,22 +403,46 @@ def test_xmin():
     assert fig.canvas.xmin == 2.5
 
 
+def test_xmin_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(xmin=4.5)
+    assert fig.canvas.xmin == 4.5
+
+
 def test_xmax():
     da = data_array(ndim=2)
     fig = da.plot(xmax=sc.scalar(7.5, unit='m'))
     assert fig.canvas.xmax == 7.5
 
 
+def test_xmax_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(xmax=8.1)
+    assert fig.canvas.xmax == 8.1
+
+
 def test_ymin():
     da = data_array(ndim=2)
-    fig = da.plot(ymin=sc.scalar(-0.5, unit='m/s'))
+    fig = da.plot(ymin=sc.scalar(-0.5, unit='m'))
     assert fig.canvas.ymin == -0.5
+
+
+def test_ymin_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(ymin=-1.0)
+    assert fig.canvas.ymin == -1.0
 
 
 def test_ymax():
     da = data_array(ndim=2)
-    fig = da.plot(ymax=sc.scalar(0.68, unit='m/s'))
+    fig = da.plot(ymax=sc.scalar(0.68, unit='m'))
     assert fig.canvas.ymax == 0.68
+
+
+def test_ymax_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(ymax=0.75)
+    assert fig.canvas.ymax == 0.75
 
 
 def test_cmin():
@@ -421,10 +451,22 @@ def test_cmin():
     assert fig.view.colormapper.cmin == 2.5
 
 
+def test_cmin_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(cmin=3.3)
+    assert fig.view.colormapper.cmin == 3.3
+
+
 def test_cmax():
     da = data_array(ndim=2)
     fig = da.plot(cmax=sc.scalar(7.5, unit='m/s'))
     assert fig.view.colormapper.cmax == 7.5
+
+
+def test_cmax_no_unit():
+    da = data_array(ndim=2)
+    fig = da.plot(cmax=8.8)
+    assert fig.view.colormapper.cmax == 8.8
 
 
 def test_logx():
@@ -462,4 +504,4 @@ def test_ylabel():
 def test_clabel():
     da = data_array(ndim=2)
     fig = da.plot(clabel='MyColorLabel')
-    assert fig.colormapper.clabel == 'MyColorLabel'
+    assert fig.view.colormapper.clabel == 'MyColorLabel'

--- a/tests/plotting/scatter_test.py
+++ b/tests/plotting/scatter_test.py
@@ -117,3 +117,113 @@ def test_scatter_does_not_accept_data_with_other_dimensionality_on_update():
         sc.DimensionError, match='Scatter only accepts data with 1 dimension'
     ):
         fig.update(new=data_array(ndim=3, dim_list="xyzab"))
+
+
+def test_xmin():
+    da = scatter_data()
+    fig = pp.scatter(da, xmin=sc.scalar(2.5, unit='m'))
+    assert fig.canvas.xmin == 2.5
+
+
+def test_xmin_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, xmin=2.5)
+    assert fig.canvas.xmin == 2.5
+
+
+def test_xmax():
+    da = scatter_data()
+    fig = pp.scatter(da, xmax=sc.scalar(7.5, unit='m'))
+    assert fig.canvas.xmax == 7.5
+
+
+def test_xmax_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, xmax=8.1)
+    assert fig.canvas.xmax == 8.1
+
+
+def test_ymin():
+    da = scatter_data()
+    fig = pp.scatter(da, ymin=sc.scalar(-0.5, unit='m'))
+    assert fig.canvas.ymin == -0.5
+
+
+def test_ymin_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, ymin=-0.6)
+    assert fig.canvas.ymin == -0.6
+
+
+def test_ymax():
+    da = scatter_data()
+    fig = pp.scatter(da, ymax=sc.scalar(0.68, unit='m'))
+    assert fig.canvas.ymax == 0.68
+
+
+def test_ymax_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, ymax=5.69)
+    assert fig.canvas.ymax == 5.69
+
+
+def test_cmin():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, cmin=sc.scalar(2.5, unit='K'))
+    assert fig.view.colormapper.cmin == 2.5
+
+
+def test_cmin_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, cmin=3.3)
+    assert fig.view.colormapper.cmin == 3.3
+
+
+def test_cmax():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, cmax=sc.scalar(7.5, unit='K'))
+    assert fig.view.colormapper.cmax == 7.5
+
+
+def test_cmax_no_unit():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, cmax=8.1)
+    assert fig.view.colormapper.cmax == 8.1
+
+
+def test_logx():
+    da = scatter_data()
+    fig = pp.scatter(da, logx=True)
+    assert fig.canvas.xscale == 'log'
+    assert fig.canvas.yscale == 'linear'
+
+
+def test_logy():
+    da = scatter_data()
+    fig = pp.scatter(da, logy=True)
+    assert fig.canvas.yscale == 'log'
+    assert fig.canvas.xscale == 'linear'
+
+
+def test_logc():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, logc=True)
+    assert fig.view.colormapper.norm == 'log'
+
+
+def test_xlabel():
+    da = scatter_data()
+    fig = pp.scatter(da, xlabel='MyXLabel')
+    assert fig.canvas.xlabel == 'MyXLabel'
+
+
+def test_ylabel():
+    da = scatter_data()
+    fig = pp.scatter(da, ylabel='MyYLabel')
+    assert fig.canvas.ylabel == 'MyYLabel'
+
+
+def test_clabel():
+    da = scatter_data()
+    fig = pp.scatter(da, cbar=True, clabel='MyColorLabel')
+    assert fig.view.colormapper.clabel == 'MyColorLabel'


### PR DESCRIPTION
This PR adds the following arguments to control the aspects of 2D plots:

- `xmin`: Left bound of the horizontal axis
- `xmax`: Right bound of the horizontal axis
- `ymin`: Lower bound of the vertical axis
- `ymax`: Upper bound of the vertical axis
- `cmin`: Lower bound of the colorscale
- `cmax`: Upper bound of the colorscale
- `logx`: make a log horizontal axis if `True`
- `logy`: make a log vertical axis if `True`
- `logc`: make a log color axis if `True`
- `xlabel`: set the horizontal axis label
- `ylabel`: set the vertical axis label
- `clabel`: set the colorbar label

The old arguments `scale={dim: 'log'}`, `norm`, `vmin`, `vmax` remain, to avoid breaking everyone's notebooks.
It is not clear if we will ever remove them.

These changes go against [Scipp-ADR0007](https://scipp.github.io/reference/developer/adr/0007-do-not-support-args-referencing-x-or-y.html), but the users are so familiar with the meaning of these arguments (from other plotting libraries) that we now feel the benefits outweigh the possible confusion they could bring.