### PR TITLE
Common docstrings and signatures for top-level plotting functions

### DIFF
--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -74,6 +74,7 @@ def inspector(
     orientation:
         Display the two panels side-by-side ('horizontal') or one below the other
         ('vertical').
+    <DOCSTRING_PLACEHOLDER>
 
     Returns
     -------

--- a/src/plopp/plotting/mesh3d.py
+++ b/src/plopp/plotting/mesh3d.py
@@ -60,6 +60,7 @@ def mesh3d(
         single solid color.
     edgecolor:
         The color of the edges. If None, no edges are drawn.
+    <DOCSTRING_PLACEHOLDER>
     """
     from ..graphics import mesh3dfigure
 

--- a/src/plopp/plotting/plot.py
+++ b/src/plopp/plotting/plot.py
@@ -34,6 +34,7 @@ def plot(
     ----------
     obj:
         The object to be plotted.
+    <DOCSTRING_PLACEHOLDER>
 
     Returns
     -------

--- a/src/plopp/plotting/scatter.py
+++ b/src/plopp/plotting/scatter.py
@@ -59,6 +59,7 @@ def scatter(
         The size of the marker. If a float is supplied, all markers will have the same
         size. If a string is supplied, it will be the name of the coordinate that is to
         be used for the size of the markers.
+    <DOCSTRING_PLACEHOLDER>
     """
     from ..graphics import scatterfigure
 

--- a/src/plopp/plotting/scatter3d.py
+++ b/src/plopp/plotting/scatter3d.py
@@ -68,6 +68,7 @@ def scatter3d(
         The name of the coordinate that is to be used for the Z positions.
     pos:
         The name of the vector coordinate that is to be used for the positions.
+    <DOCSTRING_PLACEHOLDER>
 
     Returns
     -------

--- a/src/plopp/plotting/signature.py
+++ b/src/plopp/plotting/signature.py
@@ -222,7 +222,7 @@ _DOCSTRING_LIBRARY = {
         "If ``True``, skip the check that prevents the rendering of very large data "
         "objects."
     ),
-    "mask_color": "Color of masks in 1d plots.",
+    "mask_color": "Color to use for masked data.",
     "nan_color": "Color to use for NaN values in 2d plots.",
     "title": "The figure title.",
     "legend": (
@@ -270,7 +270,11 @@ def _with_plotting_params(args):
             arg_doc = _DOCSTRING_LIBRARY.get(name, None)
             if arg_doc is not None:
                 arg_strings.append(f"    {name}:\n        {arg_doc}")
-        out.__doc__ = doc + "\n" + "\n".join(arg_strings)
+        common_docstring = "\n".join(arg_strings)
+        if "    <DOCSTRING_PLACEHOLDER>" in doc:
+            out.__doc__ = doc.replace("    <DOCSTRING_PLACEHOLDER>", common_docstring)
+        else:
+            out.__doc__ = doc + "\n" + common_docstring
         return out
 
     return deco

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -145,6 +145,7 @@ def slicer(
         Add a play button to animate the sliders if True. Defaults to False.
 
         .. versionadded:: 25.07.0
+    <DOCSTRING_PLACEHOLDER>
     """
     return Slicer(
         obj,

--- a/src/plopp/plotting/superplot.py
+++ b/src/plopp/plotting/superplot.py
@@ -26,6 +26,7 @@ def superplot(
         The single dimension to be kept, all remaining dimensions will be sliced.
         This should be a single string. If no dim is provided, the last/inner dim will
         be kept.
+    <DOCSTRING_PLACEHOLDER>
 
     Returns
     -------

--- a/src/plopp/plotting/xyplot.py
+++ b/src/plopp/plotting/xyplot.py
@@ -55,6 +55,7 @@ def xyplot(
         Must be one-dimensional.
     y:
         The variable to use as the data for the vertical axis. Must be one-dimensional.
+    <DOCSTRING_PLACEHOLDER>
     """
     x = Node(to_variable, x)
     y = Node(to_variable, y)


### PR DESCRIPTION
This is an attempt to standardize the docstrings and function signatures for the top-level plotting functions.
They are all similar, but somewhat all out of date / incomplete.

Here, we inject args and docstrings for common args in the function signatures.
Tab/auto-completion and questionmark `pp.plot?` in Jupyter/IPython still works, as well as the generated API reference doc pages.

Before:
<img width="939" height="887" alt="Screenshot_20251002_102639" src="https://github.com/user-attachments/assets/754b373d-c7dd-4073-bfe7-7f71d7ba3027" />

After:
<img width="624" height="1119" alt="Screenshot_20251002_102704" src="https://github.com/user-attachments/assets/552fd5f7-3581-4d72-afff-6cb70e3e9e55" />
