### PR TITLE
Make leaf nodes call their func when notified by a parent

### DIFF
--- a/src/plopp/core/node_class.py
+++ b/src/plopp/core/node_class.py
@@ -26,6 +26,18 @@ class Node:
     A node can be constructed from a callable ``func``, or a raw object. In the case
     of a raw object, a node wrapping the object will be created.
 
+    Nodes can have views attached to them, which are instances of :class:`View`. Views
+    can be notified when the node's data changes. When this happens, the view typically
+    requests data from its parent nodes, who in-turn request data from their parents,
+    traversing the graph from bottom to top.
+
+    Caching is used to avoid traversing the graph multiple times when data is
+    requested multiple times without any changes to the graph.
+
+    Leaf nodes are nodes that have neither children nor views. When such nodes are
+    notified of changes, they will call their ``func`` to ensure any side effects are
+    executed.
+
     Parameters
     ----------
     func:
@@ -160,6 +172,12 @@ class Node:
         _no_replace_append(self.views, view, 'view')
         view.graph_nodes[self.id] = self
 
+    def is_leaf(self) -> bool:
+        """
+        Whether the node is a leaf node (i.e. has neither children nor views).
+        """
+        return (not self.children) and (not self.views)
+
     def notify_children(self, message: Any) -> None:
         """
         Notify all of the node's children with ``message``.
@@ -172,6 +190,10 @@ class Node:
             The message to pass to the children.
         """
         self._data = None
+        if self.is_leaf():
+            # Special case: leaf nodes have no children nor views, so we simply call the
+            # `self.func` (via request_data) to ensure side effects are executed.
+            self.request_data()
         self.notify_views(message)
         for child in self.children:
             child.notify_children(message)

--- a/tests/core/node_test.py
+++ b/tests/core/node_test.py
@@ -248,6 +248,26 @@ def test_is_input_node():
     assert not b.is_input_node
 
 
+def test_is_leaf():
+    a = Node(5)
+    b = Node(lambda x: x - 2, x=a)
+    c = Node(lambda x: x + 2, x=a)
+    d = Node(lambda x, y: x * y * 3, x=a, y=b)
+    assert not a.is_leaf()
+    assert not b.is_leaf()
+    assert c.is_leaf()
+    assert d.is_leaf()
+
+
+def test_leaf_node_calls_function_on_notify():
+    log = []
+    a = Node(lambda: "Hi from a")
+    b = Node(lambda x: log.append('b, ' + x), x=a)
+    assert b.is_leaf()
+    a.notify_children(message='')
+    assert log == ['b, Hi from a']
+
+
 def test_node_operator_add():
     a = Node(5)
     b = Node(2)


### PR DESCRIPTION
Consider the following example where a graph contains nodes but no views.
The leaf node is just logging results to a container.

```Py
import plopp as pp
import numpy as np

results = []

rng = np.random.default_rng()

a = pp.Node(rng.random)
b = pp.Node(lambda x: -x, x=a)
c = pp.Node(lambda x: results.append(x), x=b)

a.notify_children("")
results```

Without the changes in this PR, the node `a` would notify `b` which would notify `c`, but `c` is not a view and would not request data and its function (and the ones in `b` and `a`) would never be called.

Now, if a leaf node is notified, it automatically requests data from parents and makes a call to it's internal function.