### PR TITLE
Lower bound fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ filterwarnings = [
   "ignore:'parseString' deprecated:DeprecationWarning",
   "ignore:'resetCache' deprecated:DeprecationWarning",
   "ignore:'enablePackrat' deprecated:DeprecationWarning",
-  "ignore:'parseAll' deprecated:DeprecationWarning",
+  "ignore:'parseAll' argument is deprecated:DeprecationWarning",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Builds at lower bound started failing because of pyparsing deprecations.
This was fixed in the latest version of Matplotlib 3.10.8, but we don't want to set this as a lower bound because of other issues (mainly https://github.com/matplotlib/ipympl/issues/594).

So instead, we filter out the deprecation warnings.

Successful nightly lower bound run: https://github.com/scipp/plopp/actions/runs/20717126072