### PR TITLE
Cbar should be False by default in scatter2d plot

### DIFF
--- a/src/plopp/plotting/scatter.py
+++ b/src/plopp/plotting/scatter.py
@@ -48,7 +48,7 @@ def scatter(
     pos: str | None = None,
     aspect: Literal['auto', 'equal', None] = None,
     autoscale: bool = True,
-    cbar: bool = True,
+    cbar: bool = False,
     clabel: str | None = None,
     cmap: str = 'viridis',
     cmax: sc.Variable | float | None = None,


### PR DESCRIPTION
This was changed to `True` by mistake in #493