### PR TITLE
Fix empty color for masked NaN values in 2d plots

### DIFF
--- a/src/plopp/graphics/colormapper.py
+++ b/src/plopp/graphics/colormapper.py
@@ -164,7 +164,7 @@ class ColorMapper:
             # (it only applied to non-masked data), so we still need to set the 'bad'
             # color here. We choose to set it to the 'over' color for a lack of a
             # better idea.
-            self.mask_cmap.set_bad(self.cmap.get_over())
+            self.mask_cmap.set_bad(self.mask_cmap.get_over())
 
         # Inside the autoscale, we need to distinguish between a min value that was set
         # by the user and one that was found by looping over all the data.


### PR DESCRIPTION
We set the bad value for the `mask_cmap` to make sure masked nans have the expected color.

Example:
```Py
import scipp as sc
import numpy as np

data = sc.array(dims=['x', 'y'], values=np.random.rand(6,6))
data['x',0]['y',0] = np.nan

mask = ~ sc.isfinite(data)
test = sc.DataArray(data=data, masks={'mask' : mask})

test.plot(mask_color='red')
```

Before:
<img width="526" height="353" alt="Screenshot_20260122_131841" src="https://github.com/user-attachments/assets/ff75786d-fec7-4415-aeaa-2b9ff5bdad5b" />

After:
<img width="533" height="355" alt="Screenshot_20260122_131823" src="https://github.com/user-attachments/assets/6a048a9d-33e6-46ff-83e7-dd9bf1094fe3" />

Fixes #509