### PR TITLE
Fix error on hover for recent versions of Numpy

### DIFF
--- a/src/plopp/backends/matplotlib/fast_image.py
+++ b/src/plopp/backends/matplotlib/fast_image.py
@@ -63,8 +63,8 @@ class FastImage:
 
         self._xmin, self._xmax = self._bin_edge_coords["x"].values[[0, -1]]
         self._ymin, self._ymax = self._bin_edge_coords["y"].values[[0, -1]]
-        self._dx = np.diff(self._bin_edge_coords["x"].values[:2])
-        self._dy = np.diff(self._bin_edge_coords["y"].values[:2])
+        self._dx = np.diff(self._bin_edge_coords["x"].values[:2])[0]
+        self._dy = np.diff(self._bin_edge_coords["y"].values[:2])[0]
 
         # Calling imshow sets the aspect ratio to 'equal', which might not be what the
         # user requested. We need to restore the original aspect ratio after making the


### PR DESCRIPTION
The `np.diff()` returns a numpy array with 1 element but crucially also 1 dimension.
In recent versions of Numpy, this now raises an error.
We extract the single element from the array to store as `dx` and `dy`.

Fixes #507

@damskii9992 can you list which version of numpy you have installed?
Can you also optionally try this patch and see if it fixes the issue for you?
Thanks!

@bingli621 see potential fix here to the issue you were having yesterday while hovering over figures.