### PR TITLE
Include upper bound in 3d view V-cut

### DIFF
--- a/src/plopp/widgets/clip3d.py
+++ b/src/plopp/widgets/clip3d.py
@@ -268,7 +268,7 @@ class ClipValueTool(ipw.HBox):
         Make a selection variable based on the current slider range.
         """
         xmin, xmax = self.range
-        return (da.data >= xmin) & (da.data < xmax)
+        return (da.data >= xmin) & (da.data <= xmax)
 
     def move(self, change: dict[str, Any]):
         # Early return if relative difference between new and old value is small.


### PR DESCRIPTION
The value-based (V) cut in 3D views was leaving out the upper bound.
Users would expect the upper bound given by the slider handle to be included in the selection (see also #526).

Example: data containing all zeros except one value = 100: the max value is left out of the selection
<img width="2214" height="1146" alt="Screenshot 2026-02-19 at 12 39 03" src="https://github.com/user-attachments/assets/890786a9-4eef-4f23-9835-acfffe0b8ca0" />

We fix this by using `<=` instead of `<` in our selection.