### PR TITLE
Speedup rectangle mode for inspector plot

### DIFF
--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -202,6 +202,13 @@ def inspector(
     Almost all the arguments for plot customization apply to the two-dimensional image
     (unless specified).
 
+    In rectangle mode, if one of the edges of the rectangle lies exactly on a bin edge
+    between two data points, the selected region does not include the data on the
+    outside of the rectangle, even though the edge is touching the rectangle.
+
+    In polygon mode, only data whose bin centers are inside the polygon are included in
+    the selected region.
+
     Parameters
     ----------
     obj:

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -60,6 +60,42 @@ def _slice_xy(da: sc.DataArray, xy: dict[str, dict[str, int]]) -> sc.DataArray:
         return sc.full_like(da[y['dim'], 0][x['dim'], 0], value=np.nan, dtype=float)
 
 
+def _slice_rectangular_region(da: sc.DataArray, rect: dict, op: str) -> sc.DataArray:
+    x = rect['x']
+    y = rect['y']
+    xmin, xmax = x['value'].min(), x['value'].max()
+    ymin, ymax = y['value'].min(), y['value'].max()
+    try:
+        # If there is a 2D coordinate in the data, we need to slice the other dimension
+        # first, as trying to slice a 2D coordinate using label-based indexing raises an
+        # error in Scipp. After slicing the other dimension, the 2D coordinate will be
+        # 1D and can be sliced normally using label-based indexing.
+        # We assume here that there would only be one multi-dimensional coordinate in a
+        # given DataArray (which is very likely the case).
+        if da.coords[y['dim']].ndim > 1:
+            out = da[x['dim'], xmin:xmax][y['dim'], ymin:ymax]
+        else:
+            out = da[y['dim'], ymin:ymax][x['dim'], xmin:xmax]
+        # If the operation is a mean, there is currently a bug in the implementation
+        # in scipp where doing a mean over a subset of the array's dimensions gives the
+        # wrong result: https://github.com/scipp/scipp/issues/3841
+        # Instead, we manually compute the mean
+        dims = (x['dim'], y['dim'])
+        if 'mean' not in op:
+            return getattr(out, op)(dims)
+        if 'nan' in op:
+            numerator = out.nansum(dims)
+            denominator = (~sc.isnan(out.data)).sum()
+        else:
+            numerator = out.sum(dims)
+            denominator = out.size
+        denominator.unit = ""
+        return numerator / denominator
+    except IndexError:
+        # If the index is out of bounds, return an empty DataArray
+        return sc.full_like(da[y['dim'], 0][x['dim'], 0], value=np.nan, dtype=float)
+
+
 def _mask_outside_polygon(
     da: sc.DataArray,
     poly: dict,
@@ -304,41 +340,50 @@ def inspector(
         ylabel=ylabel,
         **kwargs,
     )
-    if mode == 'point':
-        tool = PointsTool(
-            figure=f2d,
-            input_node=bin_edges_node,
-            func=_slice_xy,
-            destination=f1d,
-            tooltip="Activate inspector tool",
-            continuous_update=continuous_update,
-        )
-    else:
-        da = bin_centers_node()
-        xdim = f2d.canvas.dims['x']
-        ydim = f2d.canvas.dims['y']
-        x = da.coords[xdim]
-        y = da.coords[ydim]
-        sizes = {**x.sizes, **y.sizes}
-        xx = sc.broadcast(x, sizes=sizes)
-        yy = sc.broadcast(y, sizes=sizes)
-        points = np.column_stack([xx.values.ravel(), yy.values.ravel()])
-        non_nan = ~sc.isnan(da.data)
-        tools = {'polygon': PolygonTool, 'rectangle': RectangleTool}
-        tool = tools[mode](
-            figure=f2d,
-            input_node=bin_centers_node,
-            func=partial(
-                _mask_outside_polygon,
-                points=points,
-                sizes=sizes,
-                op=operation,
-                non_nan=non_nan,
-            ),
-            destination=f1d,
-            tooltip=f"Activate {mode} inspector tool",
-            continuous_update=continuous_update,
-        )
+    match mode:
+        case 'point':
+            tool = PointsTool(
+                figure=f2d,
+                input_node=bin_edges_node,
+                func=_slice_xy,
+                destination=f1d,
+                tooltip="Activate inspector tool",
+                continuous_update=continuous_update,
+            )
+        case 'rectangle':
+            tool = RectangleTool(
+                figure=f2d,
+                input_node=bin_edges_node,
+                func=partial(_slice_rectangular_region, op=operation),
+                destination=f1d,
+                tooltip="Activate rectangle inspector tool",
+                continuous_update=continuous_update,
+            )
+        case 'polygon':
+            da = bin_centers_node()
+            xdim = f2d.canvas.dims['x']
+            ydim = f2d.canvas.dims['y']
+            x = da.coords[xdim]
+            y = da.coords[ydim]
+            sizes = {**x.sizes, **y.sizes}
+            xx = sc.broadcast(x, sizes=sizes)
+            yy = sc.broadcast(y, sizes=sizes)
+            points = np.column_stack([xx.values.ravel(), yy.values.ravel()])
+            non_nan = ~sc.isnan(da.data)
+            tool = PolygonTool(
+                figure=f2d,
+                input_node=bin_centers_node,
+                func=partial(
+                    _mask_outside_polygon,
+                    points=points,
+                    sizes=sizes,
+                    op=operation,
+                    non_nan=non_nan,
+                ),
+                destination=f1d,
+                tooltip="Activate polygon inspector tool",
+                continuous_update=continuous_update,
+            )
 
     f2d.toolbar['inspect'] = tool
     out = [f2d, f1d]

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -202,7 +202,12 @@ def inspector(
     Almost all the arguments for plot customization apply to the two-dimensional image
     (unless specified).
 
-    In rectangle mode, if one of the edges of the rectangle lies exactly on a bin edge
+    In rectangle mode, if any part of a data pixel lies inside the rectangle, the whole
+    pixel is included in the selected region (as opposed to computing the overlap area).
+    This is because it is not always possible to know how the bin fraction should be
+    included, depending on the reduction operation which is applied to the data (sum,
+    mean, etc).
+    If one of the edges of the rectangle lies exactly on a bin edge
     between two data points, the selected region does not include the data on the
     outside of the rectangle, even though the edge is touching the rectangle.
 

--- a/tests/plotting/inspector_test.py
+++ b/tests/plotting/inspector_test.py
@@ -420,8 +420,8 @@ def test_rectangle_mode():
 
     # This rectangle should select the bottom left corner of the data.
     # Closing the rectangle by repeating the first point.
-    x = [-1, 21]
-    y = [-1, 310]
+    x = [-1, 19]
+    y = [-1, 290]
     for xi, yi in zip(x, y, strict=True):
         tool.click(x=xi, y=yi)
 


### PR DESCRIPTION
We use slicing for rectangle tool instead of masking like a polygon.
This yields a very large speedup.
Try out this on `main` and in this `speedup-rectangle-inspector` branch:

```Py
import plopp as pp
from plopp.data.examples import clusters3d

N = 512
da = clusters3d(nclusters=500, seed=12).hist(z=N, y=N, x=N)

pp.inspector(da, dim='z', mode='rectangle', logc=True)
```