### PR TITLE
Slicer inspector

### DIFF
--- a/docs/plotting/inspector-plot.ipynb
+++ b/docs/plotting/inspector-plot.ipynb
@@ -213,56 +213,12 @@
     "it is sometimes preferable to only update the target figure when we have stopped dragging or resizing one of the rectangles/polygons,\n",
     "instead of every step of the way.\n",
     "\n",
-    "This can be done using the `continuous_update` argument:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p = pp.inspector(\n",
-    "    da,\n",
-    "    dim='z',\n",
-    "    orientation='vertical',\n",
-    "    logc=True,\n",
-    "    mode='rectangle',\n",
-    "    continuous_update=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "tool = p.children[0].toolbar['inspect']\n",
-    "tool.value = True\n",
-    "tool._tool.click(-132, -68)\n",
-    "tool._tool.click(-56, -21)\n",
-    "tool._tool.click(4.8, 14)\n",
-    "tool._tool.click(57, 58)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p"
+    "This can be done using `continuous_update=False` in the argument list."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Changing the reduction operation\n",
@@ -279,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "17",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -321,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -14,6 +14,7 @@ from ..core.utils import coord_as_bin_edges
 from ..graphics import imagefigure, linefigure
 from ..widgets import Box, PointsTool, PolygonTool, RectangleTool
 from .common import preprocess, require_interactive_figure
+from .slicer import Slicer
 
 
 def _to_bin_edges(da: sc.DataArray, dim: str) -> sc.DataArray:
@@ -318,9 +319,10 @@ def inspector(
         dim = data.dims[-1]
     bin_edges_node = Node(_to_bin_edges, in_node, dim=dim)
     bin_centers_node = Node(_to_bin_centers, bin_edges_node, dim=dim)
-    op_node = Node(_apply_op, da=bin_edges_node, op=operation, dim=dim)
-    f2d = imagefigure(
-        op_node,
+
+    f2d = Slicer(
+        bin_edges_node,
+        keep=set(data.dims) - {dim},
         aspect=aspect,
         cbar=cbar,
         clabel=clabel,
@@ -339,7 +341,8 @@ def inspector(
         xlabel=xlabel,
         ylabel=ylabel,
         **kwargs,
-    )
+    ).figure
+
     match mode:
         case 'point':
             tool = PointsTool(

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -11,7 +11,7 @@ from matplotlib.path import Path
 from ..core import Node
 from ..core.typing import Plottable
 from ..core.utils import coord_as_bin_edges
-from ..graphics import linefigure
+from ..graphics import imagefigure, linefigure
 from ..widgets import Box, PointsTool, PolygonTool, RectangleTool
 from .common import preprocess, require_interactive_figure
 from .slicer import Slicer
@@ -33,6 +33,13 @@ def _to_bin_centers(da: sc.DataArray, dim: str) -> sc.DataArray:
     for d in set(da.dims) - {dim}:
         da.coords[d] = sc.midpoints(da.coords[d], dim=d)
     return da
+
+
+def _apply_op(da: sc.DataArray, op: str, dim: str) -> sc.DataArray:
+    out = getattr(sc, op)(da, dim=dim)
+    if out.name:
+        out.name = f'{op} of {out.name}'
+    return out
 
 
 def _slice_xy(da: sc.DataArray, xy: dict[str, dict[str, int]]) -> sc.DataArray:
@@ -159,6 +166,7 @@ def inspector(
     ylabel: str | None = None,
     ymax: sc.Variable | float | None = None,
     ymin: sc.Variable | float | None = None,
+    with_slider: bool = True,
     **kwargs,
 ):
     """
@@ -325,9 +333,7 @@ def inspector(
     bin_edges_node = Node(_to_bin_edges, in_node, dim=dim)
     bin_centers_node = Node(_to_bin_centers, bin_edges_node, dim=dim)
 
-    slicer = Slicer(
-        bin_edges_node,
-        keep=set(data.dims) - {dim},
+    f2d_args = dict(
         aspect=aspect,
         cbar=cbar,
         clabel=clabel,
@@ -340,7 +346,6 @@ def inspector(
         mask_color=mask_color,
         nan_color=nan_color,
         norm=norm,
-        operation=operation,
         title=title,
         vmax=vmax,
         vmin=vmin,
@@ -349,7 +354,31 @@ def inspector(
         **kwargs,
     )
 
-    f2d = slicer.figure
+    if with_slider:
+        slicer = Slicer(
+            bin_edges_node, keep=set(data.dims) - {dim}, operation=operation, **f2d_args
+        )
+        f2d = slicer.figure
+        span = f1d.ax.axvspan(
+            data.coords[dim].min().value,
+            data.coords[dim].max().value,
+            color='gray',
+            alpha=0.2,
+            zorder=-np.inf,
+        )
+        bin_edge_data = bin_edges_node()
+
+        def update_span(change: dict) -> None:
+            start, end = change['owner'].controls[dim].value
+            start = bin_edge_data.coords[dim][dim, start].value
+            end = bin_edge_data.coords[dim][dim, end + 1].value
+            span.set_bounds(start, 0, end - start, 1)
+            f1d.canvas.draw()
+
+        slicer.slider.observe(update_span, names='value')
+    else:
+        op_node = Node(_apply_op, da=bin_edges_node, op=operation, dim=dim)
+        f2d = imagefigure(op_node, **f2d_args)
 
     match mode:
         case 'point':
@@ -396,22 +425,22 @@ def inspector(
                 continuous_update=continuous_update,
             )
 
-    span = f1d.ax.axvspan(
-        data.coords[dim].min().value,
-        data.coords[dim].max().value,
-        color='gray',
-        alpha=0.2,
-        zorder=-np.inf,
-    )
+    # span = f1d.ax.axvspan(
+    #     data.coords[dim].min().value,
+    #     data.coords[dim].max().value,
+    #     color='gray',
+    #     alpha=0.2,
+    #     zorder=-np.inf,
+    # )
 
-    def update_span(change: dict) -> None:
-        start, end = change['owner'].controls[dim].value
-        start = data.coords[dim][dim, start].value
-        end = data.coords[dim][dim, end + 1].value
-        span.set_bounds(start, 0, end - start, 1)
-        f1d.canvas.draw()
+    # def update_span(change: dict) -> None:
+    #     start, end = change['owner'].controls[dim].value
+    #     start = data.coords[dim][dim, start].value
+    #     end = data.coords[dim][dim, end + 1].value
+    #     span.set_bounds(start, 0, end - start, 1)
+    #     f1d.canvas.draw()
 
-    slicer.slider.observe(update_span, names='value')
+    # slicer.slider.observe(update_span, names='value')
 
     f2d.toolbar['inspect'] = tool
     out = [f2d, f1d]

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -35,13 +35,6 @@ def _to_bin_centers(da: sc.DataArray, dim: str) -> sc.DataArray:
     return da
 
 
-def _apply_op(da: sc.DataArray, op: str, dim: str) -> sc.DataArray:
-    out = getattr(sc, op)(da, dim=dim)
-    if out.name:
-        out.name = f'{op} of {out.name}'
-    return out
-
-
 def _slice_xy(da: sc.DataArray, xy: dict[str, dict[str, int]]) -> sc.DataArray:
     x = xy['x']
     y = xy['y']
@@ -335,6 +328,7 @@ def inspector(
         mask_color=mask_color,
         nan_color=nan_color,
         norm=norm,
+        operation=operation,
         title=title,
         vmax=vmax,
         vmin=vmin,

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -294,6 +294,9 @@ def inspector(
         Upper limit for y-axis (1d figure).
     ymin:
         Lower limit for y-axis (1d figure).
+    with_slider:
+        Show slider under 2d image for selecting data range if ``True``. A currently
+        selected range indicator will also be displayed on the 1d profile figure.
     **kwargs:
         Additional arguments forwarded to the underlying plotting library.
 
@@ -366,12 +369,12 @@ def inspector(
             alpha=0.2,
             zorder=-np.inf,
         )
-        bin_edge_data = bin_edges_node()
+        bin_edge_coord = coord_as_bin_edges(data, dim)
 
         def update_span(change: dict) -> None:
             start, end = change['owner'].controls[dim].value
-            start = bin_edge_data.coords[dim][dim, start].value
-            end = bin_edge_data.coords[dim][dim, end + 1].value
+            start = bin_edge_coord[dim, start].value
+            end = bin_edge_coord[dim, end + 1].value
             span.set_bounds(start, 0, end - start, 1)
             f1d.canvas.draw()
 

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -320,7 +320,7 @@ def inspector(
     bin_edges_node = Node(_to_bin_edges, in_node, dim=dim)
     bin_centers_node = Node(_to_bin_centers, bin_edges_node, dim=dim)
 
-    f2d = Slicer(
+    slicer = Slicer(
         bin_edges_node,
         keep=set(data.dims) - {dim},
         aspect=aspect,
@@ -341,7 +341,9 @@ def inspector(
         xlabel=xlabel,
         ylabel=ylabel,
         **kwargs,
-    ).figure
+    )
+
+    f2d = slicer.figure
 
     match mode:
         case 'point':
@@ -387,6 +389,23 @@ def inspector(
                 tooltip="Activate polygon inspector tool",
                 continuous_update=continuous_update,
             )
+
+    span = f1d.ax.axvspan(
+        data.coords[dim].min().value,
+        data.coords[dim].max().value,
+        color='gray',
+        alpha=0.2,
+        zorder=-np.inf,
+    )
+
+    def update_span(change: dict) -> None:
+        start, end = change['owner'].controls[dim].value
+        start = data.coords[dim][dim, start].value
+        end = data.coords[dim][dim, end + 1].value
+        span.set_bounds(start, 0, end - start, 1)
+        f1d.canvas.draw()
+
+    slicer.slider.observe(update_span, names='value')
 
     f2d.toolbar['inspect'] = tool
     out = [f2d, f1d]

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -11,7 +11,7 @@ from matplotlib.path import Path
 from ..core import Node
 from ..core.typing import Plottable
 from ..core.utils import coord_as_bin_edges
-from ..graphics import imagefigure, linefigure
+from ..graphics import linefigure
 from ..widgets import Box, PointsTool, PolygonTool, RectangleTool
 from .common import preprocess, require_interactive_figure
 from .slicer import Slicer

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -428,23 +428,6 @@ def inspector(
                 continuous_update=continuous_update,
             )
 
-    # span = f1d.ax.axvspan(
-    #     data.coords[dim].min().value,
-    #     data.coords[dim].max().value,
-    #     color='gray',
-    #     alpha=0.2,
-    #     zorder=-np.inf,
-    # )
-
-    # def update_span(change: dict) -> None:
-    #     start, end = change['owner'].controls[dim].value
-    #     start = data.coords[dim][dim, start].value
-    #     end = data.coords[dim][dim, end + 1].value
-    #     span.set_bounds(start, 0, end - start, 1)
-    #     f1d.canvas.draw()
-
-    # slicer.slider.observe(update_span, names='value')
-
     f2d.toolbar['inspect'] = tool
     out = [f2d, f1d]
     if orientation == 'horizontal':


### PR DESCRIPTION
Combining the range slicer with the inspector plot:
```Py
%matplotlib widget
import plopp as pp
from plopp.data.examples import clusters3d

N = 256
da = clusters3d(nclusters=500, seed=12).hist(z=N, y=N, x=N)
pp.inspector(da, dim='z', mode='rectangle', logc=True)
```
<img width="1339" height="477" alt="Screenshot_20260411_104410" src="https://github.com/user-attachments/assets/23ae81e6-85c2-414b-9685-ae4c97876671" />

Fixes https://github.com/scipp/ess/issues/15