### PR TITLE
A more reusable Slicer

### DIFF
--- a/docs/gallery/scatter3d-with-slider.ipynb
+++ b/docs/gallery/scatter3d-with-slider.ipynb
@@ -19,7 +19,6 @@
    "outputs": [],
    "source": [
     "import plopp as pp\n",
-    "import plopp.widgets as pw\n",
     "import scipp as sc\n",
     "import numpy as np"
    ]
@@ -76,11 +75,14 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## A slider selecting a single data slice\n",
+    "## Use Plopp's in-built dimension slicer\n",
     "\n",
-    "We then construct our interface with a slider,\n",
-    "a node that slices our data at the index of the slider,\n",
-    "and a `scatter3dfigure`."
+    "To construct our interface with a slider that would output time slices of the data,\n",
+    "we leverage Plopp's in-built `Slicer` class.\n",
+    "\n",
+    "It accepts a `DataArray` as input,\n",
+    "creates sliders for the dimensions to be sliced (controlled via the `keep` argument),\n",
+    "and makes the sliced data available in its `output`."
    ]
   },
   {
@@ -90,15 +92,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use Plopp's widget to slice dimensions\n",
-    "slider = pw.SliceWidget(da, dims=['time'])\n",
-    "slider_node = pp.widget_node(slider)\n",
+    "from plopp.plotting.slicer import Slicer\n",
     "\n",
-    "slice_node = pw.slice_dims(data_array=da, slices=slider_node)\n",
+    "# Slicer object: keep the pixel dim, slice the other (time) dim\n",
+    "sl = Slicer(da, keep='pixel')\n",
     "\n",
-    "fig = pp.scatter3dfigure(slice_node, size=0.3, cbar=True)\n",
+    "# We pass the output of the slicer (which is a Node) to the scatter3d figure\n",
+    "fig = pp.scatter3dfigure(sl.output, size=0.3, cbar=True, autoscale=False)\n",
     "\n",
-    "pp.widgets.Box([fig, slider])"
+    "# Add the slider below the figure for display\n",
+    "fig.bottom_bar.add(sl.slider)\n",
+    "\n",
+    "fig"
    ]
   },
   {
@@ -106,9 +111,11 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "## A slider slicing out a range\n",
+    "## Range or single slice\n",
     "\n",
-    "It is also possible to use a `RangeSliceWidget` to create a slider with two handles that selects a data range instead of slicing using a single index:"
+    "By default, the `Slicer` will create a combined slider that allows to switch between selecting a range or a single slice.\n",
+    "\n",
+    "The mode can be chosen at creation; the possible choices are `combined`, `single`, `range`:"
    ]
   },
   {
@@ -118,18 +125,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use Plopp's widget to slice dimensions\n",
-    "slider = pw.RangeSliceWidget(da, dims=['time'])\n",
-    "slider_node = pp.widget_node(slider)\n",
+    "sl = Slicer(da, keep='pixel', mode='single')\n",
+    "fig = pp.scatter3dfigure(sl.output, size=0.3, cbar=True, autoscale=False)\n",
+    "fig.bottom_bar.add(sl.slider)\n",
     "\n",
-    "slice_node = pw.slice_dims(data_array=da, slices=slider_node)\n",
-    "\n",
-    "# Sum over the selected range of time dimension\n",
-    "sum_slices = pp.Node(sc.sum, slice_node, dim='time')\n",
-    "\n",
-    "fig = pp.scatter3dfigure(sum_slices, size=0.3, cbar=True)\n",
-    "\n",
-    "pp.widgets.Box([fig, slider])"
+    "fig"
    ]
   },
   {
@@ -158,7 +158,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/plopp/plotting/inspector.py
+++ b/src/plopp/plotting/inspector.py
@@ -14,7 +14,7 @@ from ..core.utils import coord_as_bin_edges
 from ..graphics import imagefigure, linefigure
 from ..widgets import Box, PointsTool, PolygonTool, RectangleTool
 from .common import preprocess, require_interactive_figure
-from .slicer import Slicer
+from .slicer import SlicerPlot
 
 
 def _to_bin_edges(da: sc.DataArray, dim: str) -> sc.DataArray:
@@ -358,10 +358,10 @@ def inspector(
     )
 
     if with_slider:
-        slicer = Slicer(
+        slicer_plot = SlicerPlot(
             bin_edges_node, keep=set(data.dims) - {dim}, operation=operation, **f2d_args
         )
-        f2d = slicer.figure
+        f2d = slicer_plot.figure
         span = f1d.ax.axvspan(
             data.coords[dim].min().value,
             data.coords[dim].max().value,
@@ -378,7 +378,7 @@ def inspector(
             span.set_bounds(start, 0, end - start, 1)
             f1d.canvas.draw()
 
-        slicer.slider.observe(update_span, names='value')
+        slicer_plot.slicer.slider.observe(update_span, names='value')
     else:
         op_node = Node(_apply_op, da=bin_edges_node, op=operation, dim=dim)
         f2d = imagefigure(op_node, **f2d_args)

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -119,8 +119,6 @@ class Slicer:
                 f'following dimensions were found: {[da.dims for da in dg.values()]}'
             )
 
-        # data_prototype = nodes[0]()
-        # dims = data_prototype.dims
         self.keep = _guess_keep_if_none(keep, dg.dims)
 
         if len(self.keep) == 0:
@@ -134,14 +132,17 @@ class Slicer:
             )
 
         other_dims = [dim for dim in dg.dims if dim not in self.keep]
+        data_arrays = list(dg.values())
         # Ensure all dims in other_dims (dims to be sliced) have the same coordinates
-        for dim in other_dims:
-            g = groupby(da.coords[dim] for da in dg.values())
-            if not (next(g, True) and not next(g, False)):
-                raise ValueError(
-                    f"Slicer plot: cannot slice dim '{dim}' because all inputs do not "
-                    "have the same coordinates for this dim."
-                )
+        if len(dg) > 1:
+            for dim in other_dims:
+                template = data_arrays[0]
+                for da in data_arrays[1:]:
+                    if not sc.identical(da.coords[dim], template.coords[dim]):
+                        raise ValueError(
+                            f"Slicer plot: cannot slice dim '{dim}' because all inputs "
+                            "do not have the same coordinates for this dim."
+                        )
 
         match mode:
             case 'single':
@@ -157,7 +158,7 @@ class Slicer:
                 )
 
         self.slider = slicer_constr(
-            next(iter(dg.values())), dims=other_dims, enable_player=enable_player
+            data_arrays[0], dims=other_dims, enable_player=enable_player
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -51,7 +51,9 @@ def _maybe_reduce_dim(da, dims, op):
 
 def _guess_keep_if_none(keep: list[str] | None, dims: list[str]) -> list[str]:
     if keep is None:
-        return dims[-(2 if len(dims) > 2 else 1) :]
+        keep = dims[-(2 if len(dims) > 2 else 1) :]
+    if isinstance(keep, str):
+        keep = [keep]
     return keep
 
 
@@ -107,8 +109,6 @@ class Slicer:
 
         dims = nodes[0]().dims
         keep = _guess_keep_if_none(keep, dims)
-        if isinstance(keep, str):
-            keep = [keep]
 
         # Ensure all dims in keep have the same size
         sizes = [

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -188,7 +188,6 @@ class SlicerPlot:
         ] = 'sum',
         **kwargs,
     ):
-
         self.slicer = Slicer(
             obj,
             keep=keep,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -50,8 +50,8 @@ def _maybe_reduce_dim(da, dims, op):
 
 class Slicer:
     """
-    Class that slices out dimensions from the data and displays the resulting data as
-    either a 1D line or a 2D image.
+    Class that slices out dimensions from the input data and exposes the result in
+    'output' nodes.
 
     This class exists both for simplifying unit tests and for reuse by other plotting
     functions that want to offer slicing functionality,
@@ -76,13 +76,12 @@ class Slicer:
     operation:
         The reduction operation to be applied to the sliced dimensions. This is ``sum``
         by default.
-    **kwargs:
-        The additional arguments are forwarded to the underlying 1D or 2D figures.
     """
 
     def __init__(
         self,
         obj: PlottableMulti,
+        *,
         coords: list[str] | None = None,
         enable_player: bool = False,
         keep: list[str] | None = None,
@@ -172,9 +171,38 @@ class Slicer:
 
 
 class SlicerPlot:
+    """
+    Initialize a SlicerPlot, which contains both a Slicer that slices extra
+    dimensions of the input data, and a figure that displays the result as
+    either a 1D line or a 2D image.
+
+    Parameters
+    ----------
+    obj:
+        The input data.
+    coords:
+        If supplied, use these coords instead of the input's dimension coordinates.
+    enable_player:
+        If ``True``, add a play button to the sliders to automatically step through
+        the slices.
+    keep:
+        The dimensions to be kept, all remaining dimensions will be sliced. This should
+        be a list of dims. If no dims are provided, the last dim will be kept in the
+        case of a 2-dimensional input, while the last two dims will be kept in the case
+        of higher dimensional inputs.
+    mode:
+        The mode of the slicer. This can be 'single', 'range', or 'combined'.
+    operation:
+        The reduction operation to be applied to the sliced dimensions. This is ``sum``
+        by default.
+    **kwargs:
+        The additional arguments are forwarded to the underlying 1D or 2D figures.
+    """
+
     def __init__(
         self,
         obj: PlottableMulti,
+        *,
         coords: list[str] | None = None,
         enable_player: bool = False,
         keep: list[str] | None = None,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -109,33 +109,40 @@ class Slicer:
         nodes = input_to_nodes(
             obj, processor=partial(preprocess, ignore_size=True, coords=coords)
         )
-        data_prototype = nodes[0]()
-        dims = data_prototype.dims
-        self.keep = _guess_keep_if_none(keep, dims)
 
-        # Ensure all dims in keep have the same size
-        sizes = [
-            {dim: shape for dim, shape in node().sizes.items() if dim not in self.keep}
-            for node in nodes
-        ]
-        g = groupby(sizes)
-        if not (next(g, True) and not next(g, False)):
+        # Ensure all inputs have the same dims
+        dg = sc.DataGroup({str(i): node() for i, node in enumerate(nodes)})
+        dg_dims = set(dg.dims)
+        if not all(set(da.dims) == dg_dims for da in dg.values()):
             raise ValueError(
-                'Slicer plot: all inputs must have the same sizes, but '
-                f'the following sizes were found: {sizes}'
+                'Slicer plot: all inputs must have the same dimensions, but the '
+                f'following dimensions were found: {[da.dims for da in dg.values()]}'
             )
+
+        # data_prototype = nodes[0]()
+        # dims = data_prototype.dims
+        self.keep = _guess_keep_if_none(keep, dg.dims)
 
         if len(self.keep) == 0:
             raise ValueError(
                 'Slicer plot: the list of dims to be kept cannot be empty.'
             )
-        if not all(dim in dims for dim in self.keep):
+        if not set(self.keep).issubset(dg_dims):
             raise ValueError(
                 f"Slicer plot: one or more of the requested dims to be kept {self.keep} "
-                f"were not found in the input's dimensions {dims}."
+                f"were not found in the input's dimensions {dg.dims}."
             )
 
-        other_dims = [dim for dim in dims if dim not in self.keep]
+        other_dims = [dim for dim in dg.dims if dim not in self.keep]
+        # Ensure all dims in other_dims (dims to be sliced) have the same coordinates
+        for dim in other_dims:
+            g = groupby(da.coords[dim] for da in dg.values())
+            if not (next(g, True) and not next(g, False)):
+                raise ValueError(
+                    f"Slicer plot: cannot slice dim '{dim}' because all inputs do not "
+                    "have the same coordinates for this dim."
+                )
+
         match mode:
             case 'single':
                 slicer_constr = SliceWidget
@@ -150,7 +157,7 @@ class Slicer:
                 )
 
         self.slider = slicer_constr(
-            data_prototype, dims=other_dims, enable_player=enable_player
+            next(iter(dg.values())), dims=other_dims, enable_player=enable_player
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -48,14 +48,6 @@ def _maybe_reduce_dim(da, dims, op):
     return numerator / denominator
 
 
-def _guess_keep_if_none(keep: list[str] | None, dims: list[str]) -> list[str]:
-    if keep is None:
-        keep = dims[-(2 if len(dims) > 2 else 1) :]
-    if isinstance(keep, str):
-        keep = [keep]
-    return keep
-
-
 class Slicer:
     """
     Class that slices out dimensions from the data and displays the resulting data as
@@ -118,7 +110,11 @@ class Slicer:
                 f'following dimensions were found: {[da.dims for da in dg.values()]}'
             )
 
-        self.keep = _guess_keep_if_none(keep, dg.dims)
+        self.keep = keep
+        if self.keep is None:
+            self.keep = dg.dims[-min(dg.ndim - 1, 2) :]
+        if isinstance(self.keep, str):
+            self.keep = [self.keep]
 
         if len(self.keep) == 0:
             raise ValueError(

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from functools import partial
-from itertools import groupby
 from typing import Literal
 
 import numpy as np
@@ -127,8 +126,8 @@ class Slicer:
             )
         if not set(self.keep).issubset(dg_dims):
             raise ValueError(
-                f"Slicer plot: one or more of the requested dims to be kept {self.keep} "
-                f"were not found in the input's dimensions {dg.dims}."
+                "Slicer plot: one or more of the requested dims to be kept "
+                f"{self.keep} were not found in the input's dimensions {dg.dims}."
             )
 
         other_dims = [dim for dim in dg.dims if dim not in self.keep]
@@ -189,7 +188,6 @@ class SlicerPlot:
         ] = 'sum',
         **kwargs,
     ):
-
         self.slicer = Slicer(
             obj,
             keep=keep,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -83,26 +83,19 @@ class Slicer:
 
     def __init__(
         self,
-        obj: PlottableMulti,
-        *,
-        coords: list[str] | None = None,
+        *nodes,
         enable_player: bool = False,
         keep: list[str] | None = None,
         mode: Literal['single', 'range', 'combined'] = 'combined',
         operation: Literal[
             'sum', 'mean', 'max', 'min', 'nansum', 'nanmean', 'nanmax', 'nanmin'
         ] = 'sum',
-        **kwargs,
     ):
         if enable_player and mode != 'single':
             raise ValueError(
                 'The play button cannot be used with range sliders. Please set '
                 'mode to "single" to use the play button.'
             )
-        nodes = input_to_nodes(
-            obj,
-            processor=partial(preprocess, ignore_size=True, coords=coords),
-        )
 
         dims = nodes[0]().dims
         if keep is None:
@@ -155,29 +148,56 @@ class Slicer:
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]
-        self.reduce_nodes = [
+        self.output = [
             Node(_maybe_reduce_dim, da=node, dims=other_dims, op=operation)
             for node in self.slice_nodes
         ]
 
-        # args = categorize_args(**kwargs)
 
-        # ndims = len(keep)
-        # if ndims == 1:
-        #     make_figure = partial(linefigure, **args['1d'])
-        # elif ndims == 2:
-        #     if len(self.slice_nodes) > 1:
-        #         raise_multiple_inputs_for_2d_plot_error(origin='slicer')
-        #     make_figure = partial(imagefigure, **args['2d'])
-        # else:
-        #     raise ValueError(
-        #         f'Slicer plot: the number of dims to be kept must be 1 or 2, '
-        #         f'but {ndims} were requested.'
-        #     )
+class SlicerPlot:
+    def __init__(
+        self,
+        obj: PlottableMulti,
+        coords: list[str] | None = None,
+        enable_player: bool = False,
+        keep: list[str] | None = None,
+        mode: Literal['single', 'range', 'combined'] = 'combined',
+        operation: Literal[
+            'sum', 'mean', 'max', 'min', 'nansum', 'nanmean', 'nanmax', 'nanmin'
+        ] = 'sum',
+        **kwargs,
+    ):
+        nodes = input_to_nodes(
+            obj,
+            processor=partial(preprocess, ignore_size=True, coords=coords),
+        )
 
-        # self.figure = make_figure(*self.reduce_nodes)
-        # require_interactive_figure(self.figure, 'slicer')
-        # self.figure.bottom_bar.add(self.slider)
+        self.slicer = Slicer(
+            *nodes,
+            keep=keep,
+            enable_player=enable_player,
+            mode=mode,
+            operation=operation,
+        )
+
+        args = categorize_args(**kwargs)
+
+        ndims = len(keep)
+        if ndims == 1:
+            make_figure = partial(linefigure, **args['1d'])
+        elif ndims == 2:
+            if len(self.slicer.slice_nodes) > 1:
+                raise_multiple_inputs_for_2d_plot_error(origin='slicer')
+            make_figure = partial(imagefigure, **args['2d'])
+        else:
+            raise ValueError(
+                f'Slicer plot: the number of dims to be kept must be 1 or 2, '
+                f'but {ndims} were requested.'
+            )
+
+        self.figure = make_figure(*self.slicer.output)
+        require_interactive_figure(self.figure, 'slicer')
+        self.figure.bottom_bar.add(self.slicer.slider)
 
 
 def slicer(
@@ -311,8 +331,8 @@ def slicer(
     **kwargs:
         Additional arguments forwarded to the underlying plotting library.
     """
-    sl = Slicer(
-        obj,
+    return SlicerPlot(
+        obj=obj,
         keep=keep,
         aspect=aspect,
         autoscale=autoscale,
@@ -347,24 +367,4 @@ def slicer(
         ymax=ymax,
         ymin=ymin,
         **kwargs,
-    )
-
-    args = categorize_args(**kwargs)
-
-    ndims = len(keep)
-    if ndims == 1:
-        make_figure = partial(linefigure, **args['1d'])
-    elif ndims == 2:
-        if len(sl.slice_nodes) > 1:
-            raise_multiple_inputs_for_2d_plot_error(origin='slicer')
-        make_figure = partial(imagefigure, **args['2d'])
-    else:
-        raise ValueError(
-            f'Slicer plot: the number of dims to be kept must be 1 or 2, '
-            f'but {ndims} were requested.'
-        )
-
-    figure = make_figure(*sl.reduce_nodes)
-    require_interactive_figure(figure, 'slicer')
-    figure.bottom_bar.add(sl.slider)
-    return figure
+    ).figure

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -61,8 +61,6 @@ class Slicer:
     ----------
     obj:
         The input data.
-    coords:
-        If supplied, use these coords instead of the input's dimension coordinates.
     enable_player:
         If ``True``, add a play button to the sliders to automatically step through
         the slices.
@@ -80,9 +78,8 @@ class Slicer:
 
     def __init__(
         self,
-        obj: PlottableMulti,
+        obj: PlottableMulti | list[Node] | tuple[Node, ...],
         *,
-        coords: list[str] | None = None,
         enable_player: bool = False,
         keep: list[str] | None = None,
         mode: Literal['single', 'range', 'combined'] = 'combined',
@@ -95,10 +92,10 @@ class Slicer:
                 'The play button cannot be used with range sliders. Please set '
                 'mode to "single" to use the play button.'
             )
-
-        nodes = input_to_nodes(
-            obj, processor=partial(preprocess, ignore_size=True, coords=coords)
-        )
+        if isinstance(obj, list | tuple) and ({type(x) for x in obj} == {Node}):
+            nodes = obj
+        else:
+            nodes = input_to_nodes(obj, processor=lambda x, name: x)
 
         # Ensure all inputs have the same dims
         dg = sc.DataGroup({str(i): node() for i, node in enumerate(nodes)})
@@ -162,11 +159,13 @@ class Slicer:
         ]
 
     @property
-    def output(self) -> list[Node]:
+    def output(self) -> list[Node] | Node:
         """
         Alias for ``reduce_nodes`` whose name is more like an implementation detail.
         We keep the ``reduce_nodes`` attribute for retro-compatibility.
         """
+        if len(self.reduce_nodes) == 1:
+            return self.reduce_nodes[0]
         return self.reduce_nodes
 
 
@@ -212,10 +211,13 @@ class SlicerPlot:
         ] = 'sum',
         **kwargs,
     ):
+        nodes = input_to_nodes(
+            obj, processor=partial(preprocess, ignore_size=True, coords=coords)
+        )
+
         self.slicer = Slicer(
-            obj,
+            nodes,
             keep=keep,
-            coords=coords,
             enable_player=enable_player,
             mode=mode,
             operation=operation,
@@ -236,7 +238,7 @@ class SlicerPlot:
                 f'but {ndims} were requested.'
             )
 
-        self.figure = make_figure(*self.slicer.output)
+        self.figure = make_figure(*self.slicer.reduce_nodes)
         require_interactive_figure(self.figure, 'slicer')
         self.figure.bottom_bar.add(self.slicer.slider)
 

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -160,24 +160,24 @@ class Slicer:
             for node in self.slice_nodes
         ]
 
-        args = categorize_args(**kwargs)
+        # args = categorize_args(**kwargs)
 
-        ndims = len(keep)
-        if ndims == 1:
-            make_figure = partial(linefigure, **args['1d'])
-        elif ndims == 2:
-            if len(self.slice_nodes) > 1:
-                raise_multiple_inputs_for_2d_plot_error(origin='slicer')
-            make_figure = partial(imagefigure, **args['2d'])
-        else:
-            raise ValueError(
-                f'Slicer plot: the number of dims to be kept must be 1 or 2, '
-                f'but {ndims} were requested.'
-            )
+        # ndims = len(keep)
+        # if ndims == 1:
+        #     make_figure = partial(linefigure, **args['1d'])
+        # elif ndims == 2:
+        #     if len(self.slice_nodes) > 1:
+        #         raise_multiple_inputs_for_2d_plot_error(origin='slicer')
+        #     make_figure = partial(imagefigure, **args['2d'])
+        # else:
+        #     raise ValueError(
+        #         f'Slicer plot: the number of dims to be kept must be 1 or 2, '
+        #         f'but {ndims} were requested.'
+        #     )
 
-        self.figure = make_figure(*self.reduce_nodes)
-        require_interactive_figure(self.figure, 'slicer')
-        self.figure.bottom_bar.add(self.slider)
+        # self.figure = make_figure(*self.reduce_nodes)
+        # require_interactive_figure(self.figure, 'slicer')
+        # self.figure.bottom_bar.add(self.slider)
 
 
 def slicer(
@@ -311,7 +311,7 @@ def slicer(
     **kwargs:
         Additional arguments forwarded to the underlying plotting library.
     """
-    return Slicer(
+    sl = Slicer(
         obj,
         keep=keep,
         aspect=aspect,
@@ -347,4 +347,24 @@ def slicer(
         ymax=ymax,
         ymin=ymin,
         **kwargs,
-    ).figure
+    )
+
+    args = categorize_args(**kwargs)
+
+    ndims = len(keep)
+    if ndims == 1:
+        make_figure = partial(linefigure, **args['1d'])
+    elif ndims == 2:
+        if len(sl.slice_nodes) > 1:
+            raise_multiple_inputs_for_2d_plot_error(origin='slicer')
+        make_figure = partial(imagefigure, **args['2d'])
+    else:
+        raise ValueError(
+            f'Slicer plot: the number of dims to be kept must be 1 or 2, '
+            f'but {ndims} were requested.'
+        )
+
+    figure = make_figure(*sl.reduce_nodes)
+    require_interactive_figure(figure, 'slicer')
+    figure.bottom_bar.add(sl.slider)
+    return figure

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -49,6 +49,12 @@ def _maybe_reduce_dim(da, dims, op):
     return numerator / denominator
 
 
+def _guess_keep_if_none(keep: list[str] | None, dims: list[str]) -> list[str]:
+    if keep is None:
+        return dims[-(2 if len(dims) > 2 else 1) :]
+    return keep
+
+
 class Slicer:
     """
     Class that slices out dimensions from the data and displays the resulting data as
@@ -97,10 +103,10 @@ class Slicer:
                 'mode to "single" to use the play button.'
             )
 
-        dims = nodes[0]().dims
-        if keep is None:
-            keep = dims[-(2 if len(dims) > 2 else 1) :]
+        nodes = [Node(n) if not isinstance(n, Node) else n for n in nodes]
 
+        dims = nodes[0]().dims
+        keep = _guess_keep_if_none(keep, dims)
         if isinstance(keep, str):
             keep = [keep]
 
@@ -148,10 +154,17 @@ class Slicer:
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]
-        self.output = [
+        self.reduce_nodes = [
             Node(_maybe_reduce_dim, da=node, dims=other_dims, op=operation)
             for node in self.slice_nodes
         ]
+
+    @property
+    def output(self) -> list[Node]:
+        """
+        Alias for reduce_nodes whose name is more like an implementation detail.
+        """
+        return self.reduce_nodes
 
 
 class SlicerPlot:
@@ -171,6 +184,8 @@ class SlicerPlot:
             obj,
             processor=partial(preprocess, ignore_size=True, coords=coords),
         )
+
+        keep = _guess_keep_if_none(keep, nodes[0]().dims)
 
         self.slicer = Slicer(
             *nodes,

--- a/src/plopp/plotting/slicer.py
+++ b/src/plopp/plotting/slicer.py
@@ -91,7 +91,8 @@ class Slicer:
 
     def __init__(
         self,
-        *nodes,
+        obj: PlottableMulti,
+        coords: list[str] | None = None,
         enable_player: bool = False,
         keep: list[str] | None = None,
         mode: Literal['single', 'range', 'combined'] = 'combined',
@@ -105,14 +106,16 @@ class Slicer:
                 'mode to "single" to use the play button.'
             )
 
-        nodes = [Node(n) if not isinstance(n, Node) else n for n in nodes]
-
-        dims = nodes[0]().dims
-        keep = _guess_keep_if_none(keep, dims)
+        nodes = input_to_nodes(
+            obj, processor=partial(preprocess, ignore_size=True, coords=coords)
+        )
+        data_prototype = nodes[0]()
+        dims = data_prototype.dims
+        self.keep = _guess_keep_if_none(keep, dims)
 
         # Ensure all dims in keep have the same size
         sizes = [
-            {dim: shape for dim, shape in node().sizes.items() if dim not in keep}
+            {dim: shape for dim, shape in node().sizes.items() if dim not in self.keep}
             for node in nodes
         ]
         g = groupby(sizes)
@@ -122,18 +125,17 @@ class Slicer:
                 f'the following sizes were found: {sizes}'
             )
 
-        if len(keep) == 0:
+        if len(self.keep) == 0:
             raise ValueError(
                 'Slicer plot: the list of dims to be kept cannot be empty.'
             )
-        if not all(dim in dims for dim in keep):
+        if not all(dim in dims for dim in self.keep):
             raise ValueError(
-                f"Slicer plot: one or more of the requested dims to be kept {keep} "
+                f"Slicer plot: one or more of the requested dims to be kept {self.keep} "
                 f"were not found in the input's dimensions {dims}."
             )
 
-        other_dims = [dim for dim in dims if dim not in keep]
-
+        other_dims = [dim for dim in dims if dim not in self.keep]
         match mode:
             case 'single':
                 slicer_constr = SliceWidget
@@ -148,9 +150,7 @@ class Slicer:
                 )
 
         self.slider = slicer_constr(
-            nodes[0](),
-            dims=other_dims,
-            enable_player=enable_player,
+            data_prototype, dims=other_dims, enable_player=enable_player
         )
         self.slider_node = widget_node(self.slider)
         self.slice_nodes = [slice_dims(node, self.slider_node) for node in nodes]
@@ -162,7 +162,8 @@ class Slicer:
     @property
     def output(self) -> list[Node]:
         """
-        Alias for reduce_nodes whose name is more like an implementation detail.
+        Alias for ``reduce_nodes`` whose name is more like an implementation detail.
+        We keep the ``reduce_nodes`` attribute for retro-compatibility.
         """
         return self.reduce_nodes
 
@@ -180,16 +181,11 @@ class SlicerPlot:
         ] = 'sum',
         **kwargs,
     ):
-        nodes = input_to_nodes(
-            obj,
-            processor=partial(preprocess, ignore_size=True, coords=coords),
-        )
-
-        keep = _guess_keep_if_none(keep, nodes[0]().dims)
 
         self.slicer = Slicer(
-            *nodes,
+            obj,
             keep=keep,
+            coords=coords,
             enable_player=enable_player,
             mode=mode,
             operation=operation,
@@ -197,7 +193,7 @@ class SlicerPlot:
 
         args = categorize_args(**kwargs)
 
-        ndims = len(keep)
+        ndims = len(self.slicer.keep)
         if ndims == 1:
             make_figure = partial(linefigure, **args['1d'])
         elif ndims == 2:

--- a/src/plopp/plotting/superplot.py
+++ b/src/plopp/plotting/superplot.py
@@ -7,7 +7,7 @@ import scipp as sc
 
 from ..core.typing import FigureLike, Plottable
 from ..widgets import LineSaveTool
-from .slicer import Slicer
+from .slicer import SlicerPlot
 
 
 def superplot(
@@ -109,7 +109,7 @@ def superplot(
         A :class:`widgets.Box` which will contain a :class:`graphics.FigLine`, slider
         widgets and a tool to save/delete lines.
     """
-    slicer = Slicer(
+    sp = SlicerPlot(
         obj,
         keep=keep,
         mode='single',
@@ -137,11 +137,11 @@ def superplot(
         ymin=ymin,
         **kwargs,
     )
-    slicer.figure.right_bar.add(
+    sp.figure.right_bar.add(
         LineSaveTool(
-            data_node=slicer.slice_nodes[0],
-            slider_node=slicer.slider_node,
-            fig=slicer.figure,
+            data_node=sp.slicer.slice_nodes[0],
+            slider_node=sp.slicer.slider_node,
+            fig=sp.figure,
         )
     )
-    return slicer.figure
+    return sp.figure

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -109,8 +109,8 @@ class TestSlicer1d:
 
     def test_no_keep_with_figure(self):
         da = data_array(ndim=2)
-        sl = SlicerPlot(da)
-        assert 'yy' in sl.slicer.slider.controls
+        sp = SlicerPlot(da)
+        assert 'yy' in sp.slicer.slider.controls
 
     def test_with_dataset(self):
         ds = dataset(ndim=2)
@@ -337,8 +337,8 @@ class TestSlicer2d:
 
     def test_no_keep_with_figure(self):
         da = data_array(ndim=3)
-        sl = SlicerPlot(da)
-        assert 'zz' in sl.slicer.slider.controls
+        sp = SlicerPlot(da)
+        assert 'zz' in sp.slicer.slider.controls
 
     def test_from_node_2d(self):
         da = data_array(ndim=3)
@@ -353,13 +353,13 @@ class TestSlicer2d:
         # `autoscale=True` should be the default, but there is no guarantee that it will
         # not change in the future, so we explicitly set it here to make the test
         # robust.
-        sl = SlicerPlot(da, keep=['y', 'x'], autoscale=True, mode='single')
-        cm = sl.figure.view.colormapper
+        sp = SlicerPlot(da, keep=['y', 'x'], autoscale=True, mode='single')
+        cm = sp.figure.view.colormapper
         # Colormapper fits to the values in the initial slice (slider value in the
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slicer.slider.controls['z'].value = 6
+        sp.slicer.slider.controls['z'].value = 6
         # Colormapper range fits to the values in the new slice
         assert cm.vmin == 5 * 10 * 6
         assert cm.vmax == 5 * 10 * 7 - 1
@@ -370,13 +370,13 @@ class TestSlicer2d:
                 dim='x', sizes={'z': 20, 'y': 10, 'x': 5}
             )
         )
-        sl = SlicerPlot(da, keep=['y', 'x'], autoscale=False, mode='single')
-        cm = sl.figure.view.colormapper
+        sp = SlicerPlot(da, keep=['y', 'x'], autoscale=False, mode='single')
+        cm = sp.figure.view.colormapper
         # Colormapper fits to the values in the initial slice (slider value in the
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slicer.slider.controls['z'].value = 6
+        sp.slicer.slider.controls['z'].value = 6
         # Colormapper range does not change
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -7,7 +7,7 @@ from scipp.testing import assert_allclose, assert_identical
 
 from plopp import Node
 from plopp.data.testing import data_array, dataset
-from plopp.plotting.slicer import Slicer
+from plopp.plotting.slicer import Slicer, SlicerPlot
 
 
 @pytest.mark.usefixtures("_parametrize_interactive_1d_backends")
@@ -102,29 +102,39 @@ class TestSlicer1d:
         assert sl.slider.value == {'zz': (11, 11), 'yy': (4, 4)}
         assert_identical(sl.slice_nodes[0].request_data(), da['yy', 4:5]['zz', 11:12])
 
+    def test_no_keep(self):
+        da = data_array(ndim=2)
+        sl = Slicer(da)
+        assert 'yy' in sl.slider.controls
+
+    def test_no_keep_with_figure(self):
+        da = data_array(ndim=2)
+        sl = SlicerPlot(da)
+        assert 'yy' in sl.slicer.slider.controls
+
     def test_with_dataset(self):
         ds = dataset(ndim=2)
-        sl = Slicer(ds, keep=['xx'], mode='single')
-        nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].value = 5
+        sp = SlicerPlot(ds, keep=['xx'], mode='single')
+        nodes = list(sp.figure.graph_nodes.values())
+        sp.slicer.slider.controls['yy'].value = 5
         assert_identical(nodes[0].request_data(), ds['a']['yy', 5])
         assert_identical(nodes[1].request_data(), ds['b']['yy', 5])
 
     def test_with_data_group(self):
         da = data_array(ndim=2)
         dg = sc.DataGroup(a=da, b=da * 2.5)
-        sl = Slicer(dg, keep=['xx'], mode='single')
-        nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].value = 5
+        sp = SlicerPlot(dg, keep=['xx'], mode='single')
+        nodes = list(sp.figure.graph_nodes.values())
+        sp.slicer.slider.controls['yy'].value = 5
         assert_identical(nodes[0].request_data(), dg['a']['yy', 5])
         assert_identical(nodes[1].request_data(), dg['b']['yy', 5])
 
     def test_with_dict_of_data_arrays(self):
         a = data_array(ndim=2)
         b = data_array(ndim=2) * 2.5
-        sl = Slicer({'a': a, 'b': b}, keep=['xx'], mode='single')
-        nodes = list(sl.figure.graph_nodes.values())
-        sl.slider.controls['yy'].value = 5
+        sp = SlicerPlot({'a': a, 'b': b}, keep=['xx'], mode='single')
+        nodes = list(sp.figure.graph_nodes.values())
+        sp.slicer.slider.controls['yy'].value = 5
         assert_identical(nodes[0].request_data(), a['yy', 5])
         assert_identical(nodes[1].request_data(), b['yy', 5])
 
@@ -132,12 +142,12 @@ class TestSlicer1d:
         a = data_array(ndim=2)
         b = data_array(ndim=2) * 2.5
         b.coords['xx'] *= 1.5
-        Slicer({'a': a, 'b': b}, keep=['xx'], mode='single')
+        SlicerPlot({'a': a, 'b': b}, keep=['xx'], mode='single')
 
     def test_with_data_arrays_different_shape_along_keep_dim(self):
         a = data_array(ndim=2)
         b = data_array(ndim=2) * 2.5
-        Slicer({'a': a, 'b': b['xx', :10]}, keep=['xx'], mode='single')
+        SlicerPlot({'a': a, 'b': b['xx', :10]}, keep=['xx'], mode='single')
 
     def test_with_data_arrays_different_shape_along_non_keep_dim_raises(self):
         a = data_array(ndim=2)
@@ -145,23 +155,23 @@ class TestSlicer1d:
         with pytest.raises(
             ValueError, match='Slicer plot: all inputs must have the same sizes'
         ):
-            Slicer({'a': a, 'b': b['yy', :10]}, keep=['xx'], mode='single')
+            SlicerPlot({'a': a, 'b': b['yy', :10]}, keep=['xx'], mode='single')
 
     def test_raises_ValueError_when_given_binned_data(self):
         da = sc.data.table_xyz(100).bin(x=10, y=20)
         with pytest.raises(ValueError, match='Cannot plot binned data'):
-            Slicer(da, keep=['xx'], mode='single')
+            SlicerPlot(da, keep=['xx'], mode='single')
 
     def test_from_node_1d(self):
         da = data_array(ndim=2)
-        Slicer(Node(da), mode='single')
+        SlicerPlot(Node(da), mode='single')
 
     def test_mixing_raw_data_and_nodes(self):
         a = data_array(ndim=2)
         b = 6.7 * a
-        Slicer({'a': Node(a), 'b': Node(b)}, mode='single')
-        Slicer({'a': a, 'b': Node(b)}, mode='single')
-        Slicer({'a': Node(a), 'b': b}, mode='single')
+        SlicerPlot({'a': Node(a), 'b': Node(b)}, mode='single')
+        SlicerPlot({'a': a, 'b': Node(b)}, mode='single')
+        SlicerPlot({'a': Node(a), 'b': b}, mode='single')
 
     def test_raises_when_requested_keep_dims_do_not_exist(self):
         da = data_array(ndim=3)
@@ -169,7 +179,7 @@ class TestSlicer1d:
             ValueError,
             match='Slicer plot: one or more of the requested dims to be kept',
         ):
-            Slicer(da, keep=['time'], mode='single')
+            SlicerPlot(da, keep=['time'], mode='single')
 
     def test_raises_when_number_of_keep_dims_requested_is_bad(self):
         da = data_array(ndim=4)
@@ -177,16 +187,16 @@ class TestSlicer1d:
             ValueError,
             match='Slicer plot: the number of dims to be kept must be 1 or 2',
         ):
-            Slicer(da, keep=['xx', 'yy', 'zz'], mode='single')
+            SlicerPlot(da, keep=['xx', 'yy', 'zz'], mode='single')
         with pytest.raises(
             ValueError, match='Slicer plot: the list of dims to be kept cannot be empty'
         ):
-            Slicer(da, keep=[], mode='single')
+            SlicerPlot(da, keep=[], mode='single')
 
     def test_create_with_non_dimension_coord(self):
         da = data_array(ndim=3)
         da = da.assign_coords(x_alt=da.coords['xx'] * 2).drop_coords('xx')
-        Slicer(da, keep=['x_alt'], mode='single', coords=['x_alt'])
+        SlicerPlot(da, keep=['x_alt'], mode='single', coords=['x_alt'])
 
 
 @pytest.mark.usefixtures("_parametrize_interactive_2d_backends")
@@ -287,6 +297,16 @@ class TestSlicer2d:
         assert sl.slider.value == {'zz': (10, 10)}
         assert_identical(sl.slice_nodes[0].request_data(), da['zz', 10:11])
 
+    def test_no_keep(self):
+        da = data_array(ndim=3)
+        sl = Slicer(da)
+        assert 'zz' in sl.slider.controls
+
+    def test_no_keep_with_figure(self):
+        da = data_array(ndim=3)
+        sl = SlicerPlot(da)
+        assert 'zz' in sl.slicer.slider.controls
+
     def test_from_node_2d(self):
         da = data_array(ndim=3)
         Slicer(Node(da), mode='single')
@@ -300,13 +320,13 @@ class TestSlicer2d:
         # `autoscale=True` should be the default, but there is no guarantee that it will
         # not change in the future, so we explicitly set it here to make the test
         # robust.
-        sl = Slicer(da, keep=['y', 'x'], autoscale=True, mode='single')
+        sl = SlicerPlot(da, keep=['y', 'x'], autoscale=True, mode='single')
         cm = sl.figure.view.colormapper
         # Colormapper fits to the values in the initial slice (slider value in the
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z'].value = 6
+        sl.slicer.slider.controls['z'].value = 6
         # Colormapper range fits to the values in the new slice
         assert cm.vmin == 5 * 10 * 6
         assert cm.vmax == 5 * 10 * 7 - 1
@@ -317,13 +337,13 @@ class TestSlicer2d:
                 dim='x', sizes={'z': 20, 'y': 10, 'x': 5}
             )
         )
-        sl = Slicer(da, keep=['y', 'x'], autoscale=False, mode='single')
+        sl = SlicerPlot(da, keep=['y', 'x'], autoscale=False, mode='single')
         cm = sl.figure.view.colormapper
         # Colormapper fits to the values in the initial slice (slider value in the
         # middle)
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
-        sl.slider.controls['z'].value = 6
+        sl.slicer.slider.controls['z'].value = 6
         # Colormapper range does not change
         assert cm.vmin == 5 * 10 * 9
         assert cm.vmax == 5 * 10 * 10 - 1
@@ -333,4 +353,6 @@ class TestSlicer2d:
         da = da.assign_coords(
             x_alt=da.coords['xx'] * 1.1, y_alt=da.coords['yy'] * 1.1
         ).drop_coords(['xx', 'yy'])
-        Slicer(da, keep=['y_alt', 'x_alt'], mode='single', coords=['x_alt', 'y_alt'])
+        SlicerPlot(
+            da, keep=['y_alt', 'x_alt'], mode='single', coords=['x_alt', 'y_alt']
+        )

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -18,19 +18,19 @@ class TestSlicer1d:
         assert sl.slider.value == {'zz': 14, 'yy': 19}
         assert sl.slider.controls['yy'].slider.max == da.sizes['yy'] - 1
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 19]['zz', 14])
+        assert_identical(sl.slice_nodes[0](), da['yy', 19]['zz', 14])
 
     def test_update_keep_one_dim_single_mode(self):
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx'], mode='single')
         assert sl.slider.value == {'zz': 14, 'yy': 19}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 19]['zz', 14])
+        assert_identical(sl.slice_nodes[0](), da['yy', 19]['zz', 14])
         sl.slider.controls['yy'].value = 5
         assert sl.slider.value == {'zz': 14, 'yy': 5}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 14])
+        assert_identical(sl.slice_nodes[0](), da['yy', 5]['zz', 14])
         sl.slider.controls['zz'].value = 8
         assert sl.slider.value == {'zz': 8, 'yy': 5}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 5]['zz', 8])
+        assert_identical(sl.slice_nodes[0](), da['yy', 5]['zz', 8])
 
     def test_creation_keep_one_dim_range_mode(self):
         da = data_array(ndim=3)
@@ -38,9 +38,9 @@ class TestSlicer1d:
         assert sl.slider.value == {'zz': (0, 29), 'yy': (0, 39)}
         assert sl.slider.controls['yy'].slider.max == da.sizes['yy'] - 1
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 0:40]['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['yy', 0:40]['zz', 0:30])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['yy', 0:40]['zz', 0:30].sum(['yy', 'zz']),
         )
 
@@ -48,19 +48,19 @@ class TestSlicer1d:
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx'], mode='range')
         assert sl.slider.value == {'zz': (0, 29), 'yy': (0, 39)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 0:40]['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['yy', 0:40]['zz', 0:30])
         sl.slider.controls['yy'].value = (5, 15)
         assert sl.slider.value == {'zz': (0, 29), 'yy': (5, 15)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 5:16]['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['yy', 5:16]['zz', 0:30])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['yy', 5:16]['zz', 0:30].sum(['yy', 'zz']),
         )
         sl.slider.controls['zz'].value = (10, 20)
         assert sl.slider.value == {'zz': (10, 20), 'yy': (5, 15)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 5:16]['zz', 10:21])
+        assert_identical(sl.slice_nodes[0](), da['yy', 5:16]['zz', 10:21])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['yy', 5:16]['zz', 10:21].sum(['yy', 'zz']),
         )
 
@@ -70,28 +70,28 @@ class TestSlicer1d:
         assert sl.slider.value == {'zz': (0, 29), 'yy': (0, 39)}
         assert sl.slider.controls['yy'].slider.max == da.sizes['yy'] - 1
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 0:40]['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['yy', 0:40]['zz', 0:30])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['yy', 0:40]['zz', 0:30].sum(['yy', 'zz']),
         )
         # now switch to single mode
         sl.slider.controls['yy'].slider_toggler.value = "-o-"
         sl.slider.controls['zz'].slider_toggler.value = "-o-"
         assert sl.slider.value == {'zz': (14, 14), 'yy': (19, 19)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 19:20]['zz', 14:15])
+        assert_identical(sl.slice_nodes[0](), da['yy', 19:20]['zz', 14:15])
 
     def test_update_keep_one_dim_combined_mode(self):
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx'], mode='combined')
         assert sl.slider.value == {'zz': (0, 29), 'yy': (0, 39)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 0:40]['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['yy', 0:40]['zz', 0:30])
         sl.slider.controls['yy'].value = (5, 15)
         sl.slider.controls['zz'].value = (10, 20)
         assert sl.slider.value == {'zz': (10, 20), 'yy': (5, 15)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 5:16]['zz', 10:21])
+        assert_identical(sl.slice_nodes[0](), da['yy', 5:16]['zz', 10:21])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['yy', 5:16]['zz', 10:21].sum(['yy', 'zz']),
         )
         # now switch to single mode
@@ -100,7 +100,7 @@ class TestSlicer1d:
         sl.slider.controls['yy'].value = (4, 4)
         sl.slider.controls['zz'].value = (11, 11)
         assert sl.slider.value == {'zz': (11, 11), 'yy': (4, 4)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['yy', 4:5]['zz', 11:12])
+        assert_identical(sl.slice_nodes[0](), da['yy', 4:5]['zz', 11:12])
 
     def test_no_keep(self):
         da = data_array(ndim=2)
@@ -114,29 +114,55 @@ class TestSlicer1d:
 
     def test_with_dataset(self):
         ds = dataset(ndim=2)
+        sl = Slicer(ds, keep=['xx'], mode='single')
+        nodes = sl.output
+        sl.slider.controls['yy'].value = 5
+        assert_identical(nodes[0](), ds['a']['yy', 5])
+        assert_identical(nodes[1](), ds['b']['yy', 5])
+
+    def test_with_dataset_with_figure(self):
+        ds = dataset(ndim=2)
         sp = SlicerPlot(ds, keep=['xx'], mode='single')
         nodes = list(sp.figure.graph_nodes.values())
         sp.slicer.slider.controls['yy'].value = 5
-        assert_identical(nodes[0].request_data(), ds['a']['yy', 5])
-        assert_identical(nodes[1].request_data(), ds['b']['yy', 5])
+        assert_identical(nodes[0](), ds['a']['yy', 5])
+        assert_identical(nodes[1](), ds['b']['yy', 5])
 
     def test_with_data_group(self):
+        da = data_array(ndim=2)
+        dg = sc.DataGroup(a=da, b=da * 2.5)
+        sl = Slicer(dg, keep=['xx'], mode='single')
+        nodes = sl.output
+        sl.slider.controls['yy'].value = 5
+        assert_identical(nodes[0](), dg['a']['yy', 5])
+        assert_identical(nodes[1](), dg['b']['yy', 5])
+
+    def test_with_data_group_with_figure(self):
         da = data_array(ndim=2)
         dg = sc.DataGroup(a=da, b=da * 2.5)
         sp = SlicerPlot(dg, keep=['xx'], mode='single')
         nodes = list(sp.figure.graph_nodes.values())
         sp.slicer.slider.controls['yy'].value = 5
-        assert_identical(nodes[0].request_data(), dg['a']['yy', 5])
-        assert_identical(nodes[1].request_data(), dg['b']['yy', 5])
+        assert_identical(nodes[0](), dg['a']['yy', 5])
+        assert_identical(nodes[1](), dg['b']['yy', 5])
 
     def test_with_dict_of_data_arrays(self):
+        a = data_array(ndim=2)
+        b = data_array(ndim=2) * 2.5
+        sl = Slicer({'a': a, 'b': b}, keep=['xx'], mode='single')
+        nodes = sl.output
+        sl.slider.controls['yy'].value = 5
+        assert_identical(nodes[0](), a['yy', 5])
+        assert_identical(nodes[1](), b['yy', 5])
+
+    def test_with_dict_of_data_arrays_with_figure(self):
         a = data_array(ndim=2)
         b = data_array(ndim=2) * 2.5
         sp = SlicerPlot({'a': a, 'b': b}, keep=['xx'], mode='single')
         nodes = list(sp.figure.graph_nodes.values())
         sp.slicer.slider.controls['yy'].value = 5
-        assert_identical(nodes[0].request_data(), a['yy', 5])
-        assert_identical(nodes[1].request_data(), b['yy', 5])
+        assert_identical(nodes[0](), a['yy', 5])
+        assert_identical(nodes[1](), b['yy', 5])
 
     def test_with_data_arrays_same_shape_different_coord(self):
         a = data_array(ndim=2)
@@ -214,16 +240,16 @@ class TestSlicer2d:
         sl = Slicer(da, keep=['xx', 'yy'], mode='single')
         assert sl.slider.value == {'zz': 14}
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 14])
+        assert_identical(sl.slice_nodes[0](), da['zz', 14])
 
     def test_update_keep_two_dims_single_mode(self):
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx', 'yy'], mode='single')
         assert sl.slider.value == {'zz': 14}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 14])
+        assert_identical(sl.slice_nodes[0](), da['zz', 14])
         sl.slider.controls['zz'].value = 5
         assert sl.slider.value == {'zz': 5}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 5])
+        assert_identical(sl.slice_nodes[0](), da['zz', 5])
 
     @pytest.mark.parametrize("binedges", [False, True])
     @pytest.mark.parametrize("datetime", [False, True])
@@ -238,9 +264,9 @@ class TestSlicer2d:
         sl = Slicer(da, keep=['xx', 'yy'], mode='range')
         assert sl.slider.value == {'zz': (0, 29)}
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['zz', 0:30])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['zz', 0:30].sum('zz'),
         )
 
@@ -248,12 +274,12 @@ class TestSlicer2d:
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx', 'yy'], mode='range')
         assert sl.slider.value == {'zz': (0, 29)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['zz', 0:30])
         sl.slider.controls['zz'].value = (5, 15)
         assert sl.slider.value == {'zz': (5, 15)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 5:16])
+        assert_identical(sl.slice_nodes[0](), da['zz', 5:16])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['zz', 5:16].sum('zz'),
         )
 
@@ -270,32 +296,32 @@ class TestSlicer2d:
         sl = Slicer(da, keep=['xx', 'yy'], mode='combined')
         assert sl.slider.value == {'zz': (0, 29)}
         assert sl.slider.controls['zz'].slider.max == da.sizes['zz'] - 1
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['zz', 0:30])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['zz', 0:30].sum('zz'),
         )
         # now switch to single mode
         sl.slider.controls['zz'].slider_toggler.value = "-o-"
         assert sl.slider.value == {'zz': (14, 14)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 14:15])
+        assert_identical(sl.slice_nodes[0](), da['zz', 14:15])
 
     def test_update_keep_two_dims_combined_mode(self):
         da = data_array(ndim=3)
         sl = Slicer(da, keep=['xx', 'yy'], mode='combined')
         assert sl.slider.value == {'zz': (0, 29)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 0:30])
+        assert_identical(sl.slice_nodes[0](), da['zz', 0:30])
         sl.slider.controls['zz'].value = (5, 15)
         assert sl.slider.value == {'zz': (5, 15)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 5:16])
+        assert_identical(sl.slice_nodes[0](), da['zz', 5:16])
         assert_allclose(
-            sl.reduce_nodes[0].request_data(),
+            sl.reduce_nodes[0](),
             da['zz', 5:16].sum('zz'),
         )
         # now switch to single mode
         sl.slider.controls['zz'].slider_toggler.value = "-o-"
         assert sl.slider.value == {'zz': (10, 10)}
-        assert_identical(sl.slice_nodes[0].request_data(), da['zz', 10:11])
+        assert_identical(sl.slice_nodes[0](), da['zz', 10:11])
 
     def test_no_keep(self):
         da = data_array(ndim=3)

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -178,10 +178,17 @@ class TestSlicer1d:
     def test_with_data_arrays_different_shape_along_non_keep_dim_raises(self):
         a = data_array(ndim=2)
         b = data_array(ndim=2) * 2.5
-        with pytest.raises(
-            ValueError, match='Slicer plot: all inputs must have the same sizes'
-        ):
+        with pytest.raises(ValueError, match="Slicer plot: cannot slice dim 'yy'"):
             SlicerPlot({'a': a, 'b': b['yy', :10]}, keep=['xx'], mode='single')
+
+    def test_with_data_arrays_same_shape_different_coords_along_non_keep_dim_raises(
+        self,
+    ):
+        a = data_array(ndim=2)
+        b = data_array(ndim=2) * 2.5
+        b.coords['yy'] *= 1.5
+        with pytest.raises(ValueError, match="Slicer plot: cannot slice dim 'yy'"):
+            SlicerPlot({'a': a, 'b': b}, keep=['xx'], mode='single')
 
     def test_raises_ValueError_when_given_binned_data(self):
         da = sc.data.table_xyz(100).bin(x=10, y=20)


### PR DESCRIPTION
We split the Slicer class into two parts:
- one that creates the slider widgets and slices the data (can access the result in the nodes stored in the `output` attribute
- one that creates the above + a figure 

The first one can then be used with other visualizations (e.g. the instrument view), while the second can be used by similar slicer views like the Superplot.

A quick example of something we can now do with this: update a html display from the slider
```Py
import plopp as pp
from plopp.plotting.slicer import Slicer
import ipywidgets as ipw

da = pp.data.data2d()

s = Slicer(da)

# Make a html widget
html = ipw.HTML()

# Function to display data array as html
def f(da):
    html.value = da._repr_html_()

pp.Node(f, da=s.output[0])

ipw.VBox([s.slider, html])
```
<img width="816" height="264" alt="Screenshot_20260414_194358" src="https://github.com/user-attachments/assets/368c15a3-99b3-43fa-bd75-dacc77af97d0" />

This should hopefully be quite useful for integrating as part of custom GUI interfaces.