### PR TITLE
Update positions of masked scatter points when updated

### DIFF
--- a/src/plopp/backends/matplotlib/scatter.py
+++ b/src/plopp/backends/matplotlib/scatter.py
@@ -153,12 +153,19 @@ class Scatter:
         """
         check_ndim(new_values, ndim=1, origin='Scatter')
         self._data = new_values
-        self._scatter.set_offsets(
-            np.stack(
-                [self._data.coords[self._x].values, self._data.coords[self._y].values],
-                axis=1,
-            )
+        offsets = np.stack(
+            [self._data.coords[self._x].values, self._data.coords[self._y].values],
+            axis=1,
         )
+        self._scatter.set_offsets(offsets)
+        if self._data.masks:
+            not_one_mask = ~merge_masks(self._data.masks).values
+            offsets[not_one_mask, :] = np.nan
+            self._mask.set_offsets(offsets)
+            self._mask.set_visible(True)
+        else:
+            self._mask.set_visible(False)
+
         if isinstance(self._size, str):
             self._scatter.set_sizes(self._data.coords[self._size].values)
         if self._colormapper is not None:


### PR DESCRIPTION
Example: the masked points were not being updated when the slider was used, only the orange points moved.

```Py

import plopp as pp
import scipp as sc
import ipywidgets as ipw

%matplotlib widget

a = pp.Node(pp.data.scatter())
b = pp.data.scatter(seed=2) * 10.0
b.masks['m'] = b.coords['y'] > sc.scalar(10, unit='m')
b = pp.Node(b)

slider = ipw.FloatSlider(
    min=0,
    max=60,
    value=30,
    description='Position of orange group',
    style={'description_width': 'initial'},
    layout={'width': '500px'},
)
slider_node = pp.widget_node(slider)


@pp.node
def move(da, x):
    out = da.copy(deep=False)
    out.coords['x'] = da.coords['x'] + sc.scalar(x, unit=da.coords['x'].unit)
    return out


move_node = move(da=b, x=slider_node)

f = pp.scatterfigure(a, move_node, cbar=False, autoscale=False)
f.bottom_bar.add(slider)
f.canvas.xrange = [-40, 100]
f
```
<img width="655" height="476" alt="Screenshot_20260426_222109" src="https://github.com/user-attachments/assets/76660d1e-26d8-4776-a17e-1456da0decf1" />
