### PR TITLE
Check dtypes on variables instead of numpy arrays

### DIFF
--- a/src/plopp/widgets/slicing.py
+++ b/src/plopp/widgets/slicing.py
@@ -33,13 +33,13 @@ class BoundedText(ipw.HBox, ipw.ValueWidget):
     ):
         self._lock = False
         self._coord = coord.values
-        if self._coord.dtype not in (sc.DType.datetime64, sc.DType.string):
+        if coord.dtype not in (sc.DType.datetime64, sc.DType.string):
             self._underlying = self._coord
             self._fmt = ".3E"
             if layout is None:
                 layout = {"width": "11.5ch"}
         else:
-            if self._coord.dtype == sc.DType.datetime64:
+            if coord.dtype == sc.DType.datetime64:
                 self._underlying = coord.to(unit="ns").values.astype(int)
             else:
                 self._underlying = self._coord
@@ -94,13 +94,13 @@ class BoundedBinEdgeText(ipw.HBox, ipw.ValueWidget):
     ):
         self._lock = False
         self._coord = coord.values
-        if self._coord.dtype not in (sc.DType.datetime64, sc.DType.string):
+        if coord.dtype not in (sc.DType.datetime64, sc.DType.string):
             self._underlying = self._coord
             self._fmt = ".3E"
             if layout is None:
                 layout = {"width": "22.5ch"}
         else:
-            if self._coord.dtype == sc.DType.datetime64:
+            if coord.dtype == sc.DType.datetime64:
                 self._underlying = coord.to(unit="ns").values.astype(int)
             else:
                 self._underlying = self._coord

--- a/tests/plotting/slicer_test.py
+++ b/tests/plotting/slicer_test.py
@@ -251,7 +251,7 @@ class TestSlicer2d:
             da.coords['zz'] = sc.arange(
                 'zz',
                 sc.datetime('2022-02-20T04:32:00'),
-                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"]}'),
+                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"] + binedges}'),
             )
         sl = DimensionSlicer(da, keep=['xx', 'yy'], mode='single')
         assert sl.slider.value == {'zz': 14}
@@ -275,7 +275,7 @@ class TestSlicer2d:
             da.coords['zz'] = sc.arange(
                 'zz',
                 sc.datetime('2022-02-20T04:32:00'),
-                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"]}'),
+                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"] + binedges}'),
             )
         sl = DimensionSlicer(da, keep=['xx', 'yy'], mode='range')
         assert sl.slider.value == {'zz': (0, 29)}
@@ -307,7 +307,7 @@ class TestSlicer2d:
             da.coords['zz'] = sc.arange(
                 'zz',
                 sc.datetime('2022-02-20T04:32:00'),
-                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"]}'),
+                sc.datetime(f'2022-02-20T04:32:{da.sizes["zz"] + binedges}'),
             )
         sl = DimensionSlicer(da, keep=['xx', 'yy'], mode='combined')
         assert sl.slider.value == {'zz': (0, 29)}


### PR DESCRIPTION
Some inconsistency I found while looking at the code: we were checking for datetime dtype equality between the numpy .values array dtype and the sc.DType.datetime64.

We now check on the Variable dtype.

**Edit:** The old code actually worked fine, because the equal operators between scipp and numpy dtypes actually function as excpected.
