### PR TITLE
Inspector plot: fix autoscale and allow to use a non-dimension coord for slicing

### DIFF
--- a/src/plopp/plotting/_inspector.py
+++ b/src/plopp/plotting/_inspector.py
@@ -349,6 +349,7 @@ def inspector(
 
     f2d_args = dict(
         aspect=aspect,
+        autoscale=autoscale,
         cbar=cbar,
         clabel=clabel,
         cmax=cmax,

--- a/src/plopp/plotting/_inspector.py
+++ b/src/plopp/plotting/_inspector.py
@@ -21,6 +21,8 @@ def _to_bin_edges(da: sc.DataArray, dim: str) -> sc.DataArray:
     """
     Convert dimension coords to bin edges.
     """
+    if dim not in da.dims:
+        da = da.rename_dims({da.coords[dim].dims[0]: dim})
     for d in set(da.dims) - {dim}:
         da.coords[d] = coord_as_bin_edges(da, d)
     return da
@@ -323,6 +325,15 @@ def inspector(
         ymin=ymin,
     )
     require_interactive_figure(f1d, 'inspector')
+
+    if isinstance(coords, str):
+        coords = (coords,)
+    if dim is not None:
+        if coords is not None:
+            if dim not in coords:
+                coords = (*coords, dim)
+        else:
+            coords = (dim,)
 
     in_node = Node(preprocess, obj, ignore_size=True, coords=coords)
     data = in_node()

--- a/tests/plotting/inspector_test.py
+++ b/tests/plotting/inspector_test.py
@@ -414,3 +414,17 @@ def test_different_operations(operation, mode):
         tool.click(x=xi, y=yi)
 
     assert len(fig1d.artists) == 1
+
+
+@pytest.mark.usefixtures('_use_ipympl')
+def test_use_non_dimension_coord_as_slice_dim():
+    tof = sc.arange('t', 0, 10, 1, unit='s')
+    wavelengths = sc.arange('t', 0, 200, 20, unit='nm')
+    x = sc.arange('x', 0, 7, 1, unit='m')
+    y = sc.arange('y', 0, 7, 1, unit='m')
+    data = sc.ones(dims=['t', 'y', 'x'], shape=[10, 6, 6])
+    array = sc.DataArray(
+        data=data,
+        coords={'tof': tof, 'y': y, 'x': x, 'wavelengths': wavelengths},
+    )
+    pp.inspector(array, dim='tof')


### PR DESCRIPTION
Fixes to the inspector plot:

1. Pass the `autoscale` argument to both 1d and 2d figures @ikibalin 
2. Allow to use a non-dimensional coordinate as the `dim` for slicing: fixes #566 