### PR TITLE
Fix normalization in mean operations in inspector rectangle mode

### DIFF
--- a/src/plopp/plotting/_inspector.py
+++ b/src/plopp/plotting/_inspector.py
@@ -88,11 +88,11 @@ def _slice_rectangular_region(da: sc.DataArray, rect: dict, op: str) -> sc.DataA
             return getattr(out, op)(dims)
         if 'nan' in op:
             numerator = out.nansum(dims)
-            denominator = (~sc.isnan(out.data)).sum()
+            denominator = (~sc.isnan(out.data)).sum(dims)
             denominator.unit = ""
         else:
             numerator = out.sum(dims)
-            denominator = out.size
+            denominator = out.sizes[x['dim']] * out.sizes[y['dim']]
         return numerator / denominator
     except IndexError:
         # If the index is out of bounds, return an empty DataArray


### PR DESCRIPTION
The normalization factor when computing mean was including too many dimensions, resulting in too small values in the output.
Because of the dimensions of the test data (100 in size), the values were a factor of 100 too small, and we did not notice because the numbers looked the same, just the number of decimals differed...