### PR TITLE
Add 'band' mode for errorbars

### DIFF
--- a/docs/plotting/line-plot.ipynb
+++ b/docs/plotting/line-plot.ipynb
@@ -137,6 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "da = pp.data.data1d()\n",
     "da.plot(logx=True)"
    ]
   },

--- a/docs/plotting/line-plot.ipynb
+++ b/docs/plotting/line-plot.ipynb
@@ -85,9 +85,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "## Controlling the axes\n",
-    "\n",
-    "### Logarithmic axes"
+    "## Data with errorbars"
    ]
   },
   {
@@ -97,7 +95,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.plot(logx=True)"
+    "da = pp.data.data1d(variances=True)\n",
+    "da.plot()"
    ]
   },
   {
@@ -107,12 +106,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "da.plot(errorbars='band', ls='solid', marker=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use errorbars=False to hide them\n",
+    "da.plot(errorbars=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Controlling the axes\n",
+    "\n",
+    "### Logarithmic axes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da.plot(logx=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "da.plot(logy=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Setting the axes limits\n",
@@ -123,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "17",
    "metadata": {},
    "source": [
     "Note that if the unit in the supplied limits is not identical to the data units, an on-the-fly conversion is attempted.\n",
@@ -142,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Overplotting\n",
@@ -164,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "21",
    "metadata": {},
    "source": [
     "This also works with a `Dataset` or a `DataGroup`:"
@@ -182,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Customizing line styles for multiple entries\n",
@@ -204,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "25",
    "metadata": {},
    "source": [
     "To control the style of the individual entries,\n",
@@ -223,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Bin edges\n",
@@ -248,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Masks\n",
@@ -269,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "31",
    "metadata": {},
    "source": [
     "or a thick black line in the case of bin-edges"
@@ -288,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "33",
    "metadata": {},
    "source": [
     "The color of the masks can be changed via the `mask_color` argument:"
@@ -307,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Using a non-dimension coordinate\n",
@@ -328,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "37",
    "metadata": {},
    "source": [
     "Note that if no coordinate of name `'x'` exists, a dummy one will be generated using `scipp.arange`.\n",
@@ -362,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "39",
    "metadata": {},
    "source": [
     "Any additional keyword arguments are forwarded to the `plot` function:"
@@ -383,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -103,7 +103,7 @@ def make_line_bbox(
         # Note: [str(data.dims)] is used to make a unique dim name.
         line_y = sc.DataArray(
             data=sc.concat(
-                [data.data - stddevs, data.data + stddevs], dim=[str(data.dims)]
+                [data.data - stddevs, data.data + stddevs], dim=str(data.dims)
             ),
             masks=data.masks,
         )

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -55,11 +55,7 @@ def make_line_data(data: sc.DataArray, dim: str) -> dict:
     values = {'x': xvalues, 'y': yvalues}
     mask = {'x': xvalues, 'y': np.full(y.shape, np.nan), 'visible': False}
     if data.variances is not None:
-        error = {
-            'x': xvalues,  # np.asarray(sc.midpoints(x).values) if hist else xvalues,
-            'y': yvalues,
-            'e': np.asarray(sc.stddevs(y).values),
-        }
+        error = {'x': xvalues, 'y': yvalues, 'e': np.asarray(sc.stddevs(y).values)}
     if len(data.masks):
         one_mask = np.asarray(merge_masks(data.masks).values)
         mask = {

--- a/src/plopp/backends/common.py
+++ b/src/plopp/backends/common.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-import uuid
 from typing import Literal
 
 import numpy as np
@@ -57,7 +56,7 @@ def make_line_data(data: sc.DataArray, dim: str) -> dict:
     mask = {'x': xvalues, 'y': np.full(y.shape, np.nan), 'visible': False}
     if data.variances is not None:
         error = {
-            'x': np.asarray(sc.midpoints(x).values) if hist else xvalues,
+            'x': xvalues,  # np.asarray(sc.midpoints(x).values) if hist else xvalues,
             'y': yvalues,
             'e': np.asarray(sc.stddevs(y).values),
         }
@@ -101,9 +100,10 @@ def make_line_bbox(
     line_x = data.coords[dim]
     if errorbars:
         stddevs = sc.stddevs(data.data)
+        # Note: [str(data.dims)] is used to make a unique dim name.
         line_y = sc.DataArray(
             data=sc.concat(
-                [data.data - stddevs, data.data + stddevs], dim=uuid.uuid4().hex
+                [data.data - stddevs, data.data + stddevs], dim=[str(data.dims)]
             ),
             masks=data.masks,
         )

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -50,13 +50,14 @@ class Errorbars:
         e: np.ndarray,
         color: str,
         zorder: float,
+        alpha: float,
         hist: bool,
     ):
         self._mode = ErrorbarMode[mode]
         self._ax = ax
         if self._mode == ErrorbarMode.band:
             self._artist = _fill_between(
-                ax, x, y, e, color=color, zorder=zorder, alpha=0.3, hist=hist
+                ax, x, y, e, color=color, zorder=zorder, alpha=alpha, hist=hist
             )
         elif self._mode == ErrorbarMode.bar:
             if hist:
@@ -308,6 +309,7 @@ class Line:
                 e=line_data['stddevs']['e'],
                 color=self._line.get_color(),
                 zorder=self._line.get_zorder(),
+                alpha=(({self._line.get_alpha()} - {None}) or {1.0}).pop() * 0.3,
                 hist=line_data['hist'],
             )
 

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -2,13 +2,14 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 import uuid
+from enum import Enum
 from typing import Literal
 
 import numpy as np
 import scipp as sc
+from matplotlib.axes import Axes
 from matplotlib.dates import date2num
 from matplotlib.lines import Line2D
-from numpy.typing import ArrayLike
 
 from ...graphics.bbox import BoundingBox
 from ..common import check_ndim, make_line_bbox, make_line_data
@@ -18,6 +19,87 @@ from .utils import parse_dicts_in_kwargs
 
 def _to_float(x):
     return date2num(x) if np.issubdtype(x.dtype, np.datetime64) else x
+
+
+ErrorbarMode = Enum("ErrorbarMode", [("band", 1), ("bar", 2)])
+
+
+class Errorbars:
+    """
+    Artist to represent error bars for one-dimensional data.
+    """
+
+    def __init__(
+        self,
+        mode: Literal["band", "bar"],
+        ax: Axes,
+        x: np.ndarray,
+        y: np.ndarray,
+        e: np.ndarray,
+        color,
+        zorder,
+    ):
+        self._mode = ErrorbarMode[mode]
+        if self._mode == ErrorbarMode.band:
+            self._artist = ax.fill_between(
+                x, y - e, y + e, color=color, alpha=0.3, zorder=zorder - 1
+            )
+        elif self._mode == ErrorbarMode.bar:
+            self._artist = ax.errorbar(
+                x, y, yerr=e, color=color, zorder=zorder, fmt="none"
+            )
+        else:
+            raise ValueError(f"Invalid errorbar mode: {mode}")
+
+    def update(self, x: np.ndarray, y: np.ndarray, e: np.ndarray) -> None:
+        if self._mode == ErrorbarMode.band:
+            verts = self._artist.get_paths()[0].vertices
+            if len(x) != (len(verts) - 3) // 2:
+                # We need to recreate the artist if the number of points has changed
+                color = self._artist.get_facecolor()[0]
+                alpha = self._artist.get_alpha()
+                zorder = self._artist.get_zorder()
+                self._artist.remove()
+                self._artist = self._artist.axes.fill_between(
+                    x, y - e, y + e, color=color, alpha=alpha, zorder=zorder
+                )
+            else:
+                yme = y - e
+                ype = y + e
+                verts[:, 0] = np.concatenate([x[0:1], x, [x[-1]], x[::-1], x[0:1]])
+                verts[:, 1] = np.concatenate(
+                    [ype[0:1], yme, [ype[-1]], ype[::-1], yme[0:1]]
+                )
+        else:
+            coll = self._artist.get_children()[0]
+            x, y, e = (_to_float(z) for z in (x, y, e))
+            arr1 = np.repeat(x, 2)
+            arr2 = np.array([y - e, y + e]).T.flatten()
+            coll.set_segments(np.array([arr1, arr2]).T.flatten().reshape(len(y), 2, 2))
+
+    def remove(self):
+        self._artist.remove()
+
+    def set_color(self, color):
+        if self._mode == ErrorbarMode.band:
+            self._artist.set_facecolor(color)
+        else:
+            for artist in self._artist.get_children():
+                artist.set_color(color)
+
+    def set_visible(self, visible):
+        if self._mode == ErrorbarMode.band:
+            self._artist.set_visible(visible)
+        else:
+            for artist in self._artist.get_children():
+                artist.set_visible(visible)
+
+    def set_alpha(self, alpha):
+        if self._mode == ErrorbarMode.band:
+            self._artist.set_alpha(alpha)
+        else:
+            for artist in self._artist.get_children():
+                artist.set_alpha(alpha)
 
 
 class Line:
@@ -58,6 +140,8 @@ class Line:
         self._canvas = canvas
         self._ax = self._canvas.ax
         self._data = data
+        if errorbars is True:
+            errorbars = 'bar'
 
         line_args = parse_dicts_in_kwargs(kwargs, name=data.name)
 
@@ -131,13 +215,14 @@ class Line:
 
         # Add error bars
         if errorbars and (line_data['stddevs'] is not None):
-            self._error = self._ax.errorbar(
-                line_data['stddevs']['x'],
-                line_data['stddevs']['y'],
-                yerr=line_data['stddevs']['e'],
+            self._error = Errorbars(
+                mode=errorbars,
+                ax=self._ax,
+                x=line_data['stddevs']['x'],
+                y=line_data['stddevs']['y'],
+                e=line_data['stddevs']['e'],
                 color=self._line.get_color(),
                 zorder=self._line.get_zorder(),
-                fmt="none",
             )
 
     def update(self, new_values: sc.DataArray):
@@ -158,22 +243,11 @@ class Line:
         self._mask.set_visible(line_data['mask']['visible'])
 
         if (self._error is not None) and (line_data['stddevs'] is not None):
-            coll = self._error.get_children()[0]
-            coll.set_segments(
-                self._change_segments_y(
-                    _to_float(line_data['stddevs']['x']),
-                    _to_float(line_data['stddevs']['y']),
-                    _to_float(line_data['stddevs']['e']),
-                )
+            self._error.update(
+                line_data['stddevs']['x'],
+                line_data['stddevs']['y'],
+                line_data['stddevs']['e'],
             )
-
-    def _change_segments_y(self, x: ArrayLike, y: ArrayLike, e: ArrayLike) -> ArrayLike:
-        """
-        Update the positions of the errorbars when `update_data` is called.
-        """
-        arr1 = np.repeat(x, 2)
-        arr2 = np.array([y - e, y + e]).T.flatten()
-        return np.array([arr1, arr2]).T.flatten().reshape(len(y), 2, 2)
 
     def remove(self):
         """
@@ -196,8 +270,7 @@ class Line:
     def color(self, val: str):
         self._line.set_color(val)
         if self._error is not None:
-            for artist in self._error.get_children():
-                artist.set_color(val)
+            self._error.set_color(val)
         self._canvas.draw()
 
     @property
@@ -249,8 +322,7 @@ class Line:
         self._line.set_visible(val)
         self._mask.set_visible(val)
         if self._error is not None:
-            for artist in self._error.get_children():
-                artist.set_visible(val)
+            self._error.set_visible(val)
         self._canvas.draw()
 
     @property
@@ -265,8 +337,7 @@ class Line:
         self._line.set_alpha(val)
         self._mask.set_alpha(val)
         if self._error is not None:
-            for artist in self._error.get_children():
-                artist.set_alpha(val)
+            self._error.set_alpha(val)
         self._canvas.draw()
 
     def bbox(

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -36,41 +36,50 @@ class Errorbars:
         x: np.ndarray,
         y: np.ndarray,
         e: np.ndarray,
-        color,
-        zorder,
+        color: str,
+        zorder: float,
+        hist: bool,
     ):
         self._mode = ErrorbarMode[mode]
+        self._ax = ax
         if self._mode == ErrorbarMode.band:
+            yme, ype = y - e, y + e
+            extra_arg = {}
+            if hist:
+                yme = np.concatenate([yme[0:1], yme])
+                ype = np.concatenate([ype[0:1], ype])
+                extra_arg = {"step": "pre"}
             self._artist = ax.fill_between(
-                x, y - e, y + e, color=color, alpha=0.3, zorder=zorder - 1
+                x, yme, ype, color=color, alpha=0.3, zorder=zorder - 1, **extra_arg
             )
         elif self._mode == ErrorbarMode.bar:
+            if hist:
+                x = 0.5 * (x[1:] + x[:-1])  # Use bin centers for error bars
             self._artist = ax.errorbar(
                 x, y, yerr=e, color=color, zorder=zorder, fmt="none"
             )
         else:
             raise ValueError(f"Invalid errorbar mode: {mode}")
 
-    def update(self, x: np.ndarray, y: np.ndarray, e: np.ndarray) -> None:
+    def update(self, x: np.ndarray, y: np.ndarray, e: np.ndarray, hist: bool) -> None:
         if self._mode == ErrorbarMode.band:
-            verts = self._artist.get_paths()[0].vertices
-            if len(x) != (len(verts) - 3) // 2:
-                # We need to recreate the artist if the number of points has changed
-                color = self._artist.get_facecolor()[0]
-                alpha = self._artist.get_alpha()
-                zorder = self._artist.get_zorder()
-                self._artist.remove()
-                self._artist = self._artist.axes.fill_between(
-                    x, y - e, y + e, color=color, alpha=alpha, zorder=zorder
-                )
-            else:
-                yme = y - e
-                ype = y + e
-                verts[:, 0] = np.concatenate([x[0:1], x, [x[-1]], x[::-1], x[0:1]])
-                verts[:, 1] = np.concatenate(
-                    [ype[0:1], yme, [ype[-1]], ype[::-1], yme[0:1]]
-                )
+            yme = y - e
+            ype = y + e
+            extra_arg = {}
+            if hist:
+                yme = np.concatenate([yme[0:1], yme])
+                ype = np.concatenate([ype[0:1], ype])
+                extra_arg = {"step": "pre"}
+            color = self._artist.get_facecolor()[0]
+            alpha = self._artist.get_alpha()
+            zorder = self._artist.get_zorder()
+            self._artist.remove()
+            self._artist = self._ax.fill_between(
+                x, yme, ype, color=color, alpha=alpha, zorder=zorder, **extra_arg
+            )
         else:
+            if hist:
+                x = 0.5 * (x[1:] + x[:-1])  # Use bin centers for bars
             coll = self._artist.get_children()[0]
             x, y, e = (_to_float(z) for z in (x, y, e))
             arr1 = np.repeat(x, 2)
@@ -282,6 +291,7 @@ class Line:
                 e=line_data['stddevs']['e'],
                 color=self._line.get_color(),
                 zorder=self._line.get_zorder(),
+                hist=line_data['hist'],
             )
 
     def update(self, new_values: sc.DataArray):
@@ -303,9 +313,10 @@ class Line:
 
         if (self._error is not None) and (line_data['stddevs'] is not None):
             self._error.update(
-                line_data['stddevs']['x'],
-                line_data['stddevs']['y'],
-                line_data['stddevs']['e'],
+                x=line_data['stddevs']['x'],
+                y=line_data['stddevs']['y'],
+                e=line_data['stddevs']['e'],
+                hist=line_data['hist'],
             )
 
     def remove(self):

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -24,6 +24,18 @@ def _to_float(x):
 ErrorbarMode = Enum("ErrorbarMode", [("band", 1), ("bar", 2)])
 
 
+def _fill_between(ax, x, y, e, color, zorder, alpha, hist):
+    yme, ype = y - e, y + e
+    extra_arg = {}
+    if hist:
+        yme = np.concatenate([yme[0:1], yme])
+        ype = np.concatenate([ype[0:1], ype])
+        extra_arg = {"step": "pre"}
+    return ax.fill_between(
+        x, yme, ype, color=color, alpha=alpha, zorder=zorder - 1, **extra_arg
+    )
+
+
 class Errorbars:
     """
     Artist to represent error bars for one-dimensional data.
@@ -43,14 +55,8 @@ class Errorbars:
         self._mode = ErrorbarMode[mode]
         self._ax = ax
         if self._mode == ErrorbarMode.band:
-            yme, ype = y - e, y + e
-            extra_arg = {}
-            if hist:
-                yme = np.concatenate([yme[0:1], yme])
-                ype = np.concatenate([ype[0:1], ype])
-                extra_arg = {"step": "pre"}
-            self._artist = ax.fill_between(
-                x, yme, ype, color=color, alpha=0.3, zorder=zorder - 1, **extra_arg
+            self._artist = _fill_between(
+                ax, x, y, e, color=color, zorder=zorder, alpha=0.3, hist=hist
             )
         elif self._mode == ErrorbarMode.bar:
             if hist:
@@ -65,18 +71,37 @@ class Errorbars:
         if self._mode == ErrorbarMode.band:
             yme = y - e
             ype = y + e
-            extra_arg = {}
-            if hist:
-                yme = np.concatenate([yme[0:1], yme])
-                ype = np.concatenate([ype[0:1], ype])
-                extra_arg = {"step": "pre"}
-            color = self._artist.get_facecolor()[0]
-            alpha = self._artist.get_alpha()
-            zorder = self._artist.get_zorder()
-            self._artist.remove()
-            self._artist = self._ax.fill_between(
-                x, yme, ype, color=color, alpha=alpha, zorder=zorder, **extra_arg
-            )
+            verts = self._artist.get_paths()[0].vertices
+            # In the case of bin-edge histogram, we have more vertices in the step
+            # function: 4 * len(y) + 4. In the case of bin centers, the fill using lines
+            # has 2 * len(y) + 3 vertices.
+            if len(verts) != (len(y) * 2 * (1 + hist) + 3 + hist):
+                # We need to recreate the artist if the number of points has changed
+                self._artist.remove()
+                self._artist = _fill_between(
+                    self._ax,
+                    x,
+                    y,
+                    e,
+                    color=self._artist.get_facecolor()[0],
+                    zorder=self._artist.get_zorder(),
+                    alpha=self._artist.get_alpha(),
+                    hist=hist,
+                )
+            else:
+                if hist:
+                    x2 = np.repeat(x, 2)
+                    xverts = np.concatenate([x[0:1], x2, x2[::-1][1:], x[0:1]])
+                    a = np.repeat(yme, 2)
+                    b = np.repeat(ype, 2)[::-1]
+                    yverts = np.concatenate([[b[-1]], a[0:1], a, b[0:1], b, b[-2:]])
+                else:
+                    xverts = np.concatenate([x[0:1], x, [x[-1]], x[::-1], x[0:1]])
+                    yverts = np.concatenate(
+                        [ype[0:1], yme, [ype[-1]], ype[::-1], yme[0:1]]
+                    )
+                verts[:, 0] = _to_float(xverts)
+                verts[:, 1] = _to_float(yverts)
         else:
             if hist:
                 x = 0.5 * (x[1:] + x[:-1])  # Use bin centers for bars

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -60,7 +60,9 @@ class Errorbars:
             )
         elif self._mode == ErrorbarMode.bar:
             if hist:
-                x = 0.5 * (x[1:] + x[:-1])  # Use bin centers for error bars
+                # Use bin centers for bars; We go via sc.midpoints as it handles
+                # datetime coordinates correctly.
+                x = np.asarray(sc.midpoints(sc.array(dims='x', values=x)).values)
             self._artist = ax.errorbar(
                 x, y, yerr=e, color=color, zorder=zorder, fmt="none"
             )
@@ -68,9 +70,9 @@ class Errorbars:
             raise ValueError(f"Invalid errorbar mode: {mode}")
 
     def update(self, x: np.ndarray, y: np.ndarray, e: np.ndarray, hist: bool) -> None:
+        yme = y - e
+        ype = y + e
         if self._mode == ErrorbarMode.band:
-            yme = y - e
-            ype = y + e
             verts = self._artist.get_paths()[0].vertices
             # In the case of bin-edge histogram, we have more vertices in the step
             # function: 4 * len(y) + 4. In the case of bin centers, the fill using lines
@@ -101,14 +103,17 @@ class Errorbars:
                         [ype[0:1], yme, [ype[-1]], ype[::-1], yme[0:1]]
                     )
                 verts[:, 0] = _to_float(xverts)
-                verts[:, 1] = _to_float(yverts)
+                verts[:, 1] = yverts
         else:
+            # Note that we only need to convert the x values to float if they are
+            # datetime, as the y values are always floats (variances on data with
+            # datetime dtype is not supported in scipp).
+            x = _to_float(x)
             if hist:
                 x = 0.5 * (x[1:] + x[:-1])  # Use bin centers for bars
             coll = self._artist.get_children()[0]
-            x, y, e = (_to_float(z) for z in (x, y, e))
             arr1 = np.repeat(x, 2)
-            arr2 = np.array([y - e, y + e]).T.flatten()
+            arr2 = np.array([yme, ype]).T.flatten()
             coll.set_segments(np.array([arr1, arr2]).T.flatten().reshape(len(y), 2, 2))
 
     def remove(self):
@@ -166,32 +171,19 @@ class Errorbars:
             for artist in self._artist.get_children():
                 artist.set_zorder(zorder)
 
-    @property
-    def x(self):
+    def get_xdata(self) -> np.ndarray:
         if self._mode == ErrorbarMode.band:
-            verts = self._artist.get_paths()[0].vertices
-            return verts[1 : (len(verts) - 3) // 2 + 1, 0]
+            return self._artist.get_paths()[0].vertices[:, 0]
         else:
             coll = self._artist.get_children()[0]
-            return np.array(coll.get_segments())[:, 0, 0]
+            return np.array(coll.get_segments())[:, :, 0]
 
-    @property
-    def ylower(self):
+    def get_ydata(self) -> np.ndarray:
         if self._mode == ErrorbarMode.band:
-            verts = self._artist.get_paths()[0].vertices
-            return verts[1 : (len(verts) - 3) // 2 + 1, 1]
+            return self._artist.get_paths()[0].vertices[:, 1]
         else:
             coll = self._artist.get_children()[0]
-            return np.array(coll.get_segments())[:, 0, 1]
-
-    @property
-    def yupper(self):
-        if self._mode == ErrorbarMode.band:
-            verts = self._artist.get_paths()[0].vertices
-            return verts[(len(verts) - 3) // 2 + 2 : -1, 1][::-1]
-        else:
-            coll = self._artist.get_children()[0]
-            return np.array(coll.get_segments())[:, 1, 1]
+            return np.array(coll.get_segments())[:, :, 1]
 
 
 class Line:

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -120,7 +120,8 @@ class Line:
         The canvas keeps track of how many lines have been added to it. This number is
         used to set the color and marker parameters of the line.
     errorbars:
-        Whether to add error bars to the line.
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar'.
     mask_color:
         The color of the masked points.
     """
@@ -131,7 +132,7 @@ class Line:
         data: sc.DataArray,
         uid: str | None = None,
         artist_number: int = 0,
-        errorbars: bool = True,
+        errorbars: Literal['band', 'bar', True, False] = True,
         mask_color: str | None = None,
         **kwargs,
     ):

--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -80,12 +80,24 @@ class Errorbars:
     def remove(self):
         self._artist.remove()
 
+    def get_color(self) -> str:
+        if self._mode == ErrorbarMode.band:
+            return self._artist.get_facecolor()[0]
+        else:
+            return self._artist.get_children()[0].get_color()
+
     def set_color(self, color):
         if self._mode == ErrorbarMode.band:
             self._artist.set_facecolor(color)
         else:
             for artist in self._artist.get_children():
                 artist.set_color(color)
+
+    def get_visible(self) -> bool:
+        if self._mode == ErrorbarMode.band:
+            return self._artist.get_visible()
+        else:
+            return self._artist.get_children()[0].get_visible()
 
     def set_visible(self, visible):
         if self._mode == ErrorbarMode.band:
@@ -94,12 +106,58 @@ class Errorbars:
             for artist in self._artist.get_children():
                 artist.set_visible(visible)
 
+    def get_alpha(self) -> float:
+        if self._mode == ErrorbarMode.band:
+            return self._artist.get_alpha()
+        else:
+            return self._artist.get_children()[0].get_alpha()
+
     def set_alpha(self, alpha):
         if self._mode == ErrorbarMode.band:
             self._artist.set_alpha(alpha)
         else:
             for artist in self._artist.get_children():
                 artist.set_alpha(alpha)
+
+    def get_zorder(self) -> float:
+        if self._mode == ErrorbarMode.band:
+            return self._artist.get_zorder()
+        else:
+            return self._artist.get_children()[0].get_zorder()
+
+    def set_zorder(self, zorder):
+        if self._mode == ErrorbarMode.band:
+            self._artist.set_zorder(zorder)
+        else:
+            for artist in self._artist.get_children():
+                artist.set_zorder(zorder)
+
+    @property
+    def x(self):
+        if self._mode == ErrorbarMode.band:
+            verts = self._artist.get_paths()[0].vertices
+            return verts[1 : (len(verts) - 3) // 2 + 1, 0]
+        else:
+            coll = self._artist.get_children()[0]
+            return np.array(coll.get_segments())[:, 0, 0]
+
+    @property
+    def ylower(self):
+        if self._mode == ErrorbarMode.band:
+            verts = self._artist.get_paths()[0].vertices
+            return verts[1 : (len(verts) - 3) // 2 + 1, 1]
+        else:
+            coll = self._artist.get_children()[0]
+            return np.array(coll.get_segments())[:, 0, 1]
+
+    @property
+    def yupper(self):
+        if self._mode == ErrorbarMode.band:
+            verts = self._artist.get_paths()[0].vertices
+            return verts[(len(verts) - 3) // 2 + 2 : -1, 1][::-1]
+        else:
+            coll = self._artist.get_children()[0]
+            return np.array(coll.get_segments())[:, 1, 1]
 
 
 class Line:

--- a/src/plopp/plotting/_inspector.py
+++ b/src/plopp/plotting/_inspector.py
@@ -145,7 +145,7 @@ def inspector(
     cmin: sc.Variable | float | None = None,
     continuous_update: bool = True,
     coords: list[str] | None = None,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     legend: bool | tuple[float, float] = True,
@@ -246,7 +246,8 @@ def inspector(
     coords:
         If supplied, use these coords instead of the input's dimension coordinates.
     errorbars:
-        Show errorbars if ``True`` (1d figure).
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar' (1d figure).
     figsize:
         The width and height of the figure, in inches.
     grid:

--- a/src/plopp/plotting/_plot.py
+++ b/src/plopp/plotting/_plot.py
@@ -27,7 +27,7 @@ def plot(
     cmax: sc.Variable | float | None = None,
     cmin: sc.Variable | float | None = None,
     coords: list[str] | None = None,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     ignore_size: bool = False,
@@ -74,7 +74,8 @@ def plot(
     coords:
         If supplied, use these coords instead of the input's dimension coordinates.
     errorbars:
-        Show errorbars in 1d plots if ``True``.
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar'.
     figsize:
         The width and height of the figure, in inches.
     grid:

--- a/src/plopp/plotting/_slicer.py
+++ b/src/plopp/plotting/_slicer.py
@@ -257,7 +257,7 @@ def slicer(
     cmin: sc.Variable | float | None = None,
     coords: list[str] | None = None,
     enable_player: bool = False,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     legend: bool | tuple[float, float] = True,
@@ -316,7 +316,8 @@ def slicer(
         If ``True``, add a play button to the sliders to automatically step through
         the slices.
     errorbars:
-        Show errorbars in 1d plots if ``True``.
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar'.
     figsize:
         The width and height of the figure, in inches.
     grid:

--- a/src/plopp/plotting/_superplot.py
+++ b/src/plopp/plotting/_superplot.py
@@ -18,7 +18,7 @@ def superplot(
     autoscale: bool = True,
     coords: list[str] | None = None,
     enable_player: bool = False,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     legend: bool | tuple[float, float] = True,
@@ -62,7 +62,8 @@ def superplot(
         If ``True``, add a play button to the sliders to automatically step through
         the slices.
     errorbars:
-        Show errorbars in 1d plots if ``True``.
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar'.
     figsize:
         The width and height of the figure, in inches.
     grid:

--- a/src/plopp/plotting/_xyplot.py
+++ b/src/plopp/plotting/_xyplot.py
@@ -42,7 +42,7 @@ def xyplot(
     y: sc.Variable | ndarray | list | Node,
     aspect: Literal['auto', 'equal'] | None = None,
     autoscale: bool = True,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     legend: bool | tuple[float, float] = True,
@@ -78,7 +78,8 @@ def xyplot(
     autoscale:
         Automatically scale the axes on updates if ``True``.
     errorbars:
-        Show errorbars in 1d plots if ``True``.
+        Whether to add error bars to the line. Optionally, this can be a string to
+        specify the error bar style. Valid values are 'band' and 'bar'.
     figsize:
         The width and height of the figure, in inches.
     grid:

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -354,7 +354,7 @@ def categorize_args(
     cmap: str = 'viridis',
     cmax: sc.Variable | float | None = None,
     cmin: sc.Variable | float | None = None,
-    errorbars: bool = True,
+    errorbars: Literal['band', 'bar', True, False] = True,
     figsize: tuple[float, float] | None = None,
     grid: bool = False,
     legend: bool | tuple[float, float] = True,

--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -30,25 +30,22 @@ def test_line_creation_bin_edges():
     assert len(line._line.get_xdata()) == da.sizes['xx'] + 1
 
 
-def test_line_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_line_with_errorbars(mode):
     da = data_array(ndim=1, variances=True)
-    line = Line(canvas=Canvas(), data=da)
-    assert line._error.has_yerr
-    coll = line._error.get_children()[0]
-    x = np.array(coll.get_segments())[:, 0, 0]
-    y1 = np.array(coll.get_segments())[:, 0, 1]
-    y2 = np.array(coll.get_segments())[:, 1, 1]
-    assert np.allclose(x, da.coords['xx'].values)
-    assert np.allclose(y1, (da.data - sc.stddevs(da.data)).values)
-    assert np.allclose(y2, (da.data + sc.stddevs(da.data)).values)
+    line = Line(canvas=Canvas(), data=da, errorbars=mode)
+    assert np.allclose(line._error.x, da.coords['xx'].values)
+    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
+    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
 
 
-def test_line_with_bin_edges_and_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_line_with_bin_edges_and_errorbars(mode):
     da = data_array(ndim=1, binedges=True, variances=True)
-    line = Line(canvas=Canvas(), data=da)
-    coll = line._error.get_children()[0]
-    x = np.array(coll.get_segments())[:, 0, 0]
-    assert np.allclose(x, sc.midpoints(da.coords['xx']).values)
+    line = Line(canvas=Canvas(), data=da, errorbars=mode)
+    assert np.allclose(line._error.x, sc.midpoints(da.coords['xx']).values)
+    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
+    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
 
 
 def test_line_hide_errorbars():
@@ -88,27 +85,23 @@ def test_line_update():
     assert np.allclose(line._line.get_ydata(), da.values * 2.5)
 
 
-def test_line_update_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_line_update_with_errorbars(mode):
     da = data_array(ndim=1, variances=True)
-    line = Line(canvas=Canvas(), data=da)
-    coll = line._error.get_children()[0]
-    x = np.array(coll.get_segments())[:, 0, 0]
-    y1 = np.array(coll.get_segments())[:, 0, 1]
-    y2 = np.array(coll.get_segments())[:, 1, 1]
-    assert np.allclose(x, da.coords['xx'].values)
-    assert np.allclose(y1, (da.data - sc.stddevs(da.data)).values)
-    assert np.allclose(y2, (da.data + sc.stddevs(da.data)).values)
+    line = Line(canvas=Canvas(), data=da, errorbars=mode)
+    assert np.allclose(line._error.x, da.coords['xx'].values)
+    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
+    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
     new_values = da * 2.5
     new_values.variances = da.variances
     line.update(new_values)
-    coll = line._error.get_children()[0]
-    y1 = np.array(coll.get_segments())[:, 0, 1]
-    y2 = np.array(coll.get_segments())[:, 1, 1]
-    assert np.allclose(y1, (da.data * 2.5 - sc.stddevs(da.data)).values)
-    assert np.allclose(y2, (da.data * 2.5 + sc.stddevs(da.data)).values)
+    assert np.allclose(line._error.x, da.coords['xx'].values)
+    assert np.allclose(line._error.ylower, (da.data * 2.5 - sc.stddevs(da.data)).values)
+    assert np.allclose(line._error.yupper, (da.data * 2.5 + sc.stddevs(da.data)).values)
 
 
-def test_line_datetime_binedges_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_line_datetime_binedges_with_errorbars(mode):
     t = np.arange(
         np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
     )
@@ -157,18 +150,19 @@ def test_kwarg_marker():
     assert line._line.get_marker() == '+'
 
 
-def test_line_color_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_line_color_with_errorbars(mode):
     from matplotlib.colors import to_hex
 
     da = data_array(ndim=1, variances=True)
-    line = Line(canvas=Canvas(), data=da, color='C0')
+    line = Line(canvas=Canvas(), data=da, color='C0', errorbars=mode)
     assert line.color == 'C0'
     assert line._line.get_color() == 'C0'
-    assert to_hex(line._error.get_children()[0].get_color()) == to_hex('C0')
+    assert to_hex(line._error.get_color()) == to_hex('C0')
     line.color = 'C1'
     assert line.color == 'C1'
     assert line._line.get_color() == 'C1'
-    assert to_hex(line._error.get_children()[0].get_color()) == to_hex('C1')
+    assert to_hex(line._error.get_color()) == to_hex('C1')
 
 
 def test_kwarg_zorder():
@@ -198,8 +192,18 @@ def test_kwarg_zorder_binedges_masks():
 def test_kwarg_zorder_errorbars():
     line = Line(canvas=Canvas(), data=data_array(ndim=1, variances=True), zorder=12)
     assert line._line.get_zorder() == 12
-    for artist in line._error.get_children():
-        assert artist.get_zorder() == 12
+    assert line._error.get_zorder() == 12
+
+
+def test_kwarg_zorder_errorbars_band_mode():
+    line = Line(
+        canvas=Canvas(),
+        data=data_array(ndim=1, variances=True),
+        zorder=13,
+        errorbars='band',
+    )
+    assert line._line.get_zorder() == 13
+    assert line._error.get_zorder() == 12  # band is below the line
 
 
 def test_kwarg_zorder_binedges_errorbars():
@@ -209,5 +213,15 @@ def test_kwarg_zorder_binedges_errorbars():
         zorder=14,
     )
     assert line._line.get_zorder() == 14
-    for artist in line._error.get_children():
-        assert artist.get_zorder() == 14
+    assert line._error.get_zorder() == 14
+
+
+def test_kwarg_zorder_binedges_errorbars_band_mode():
+    line = Line(
+        canvas=Canvas(),
+        data=data_array(ndim=1, binedges=True, variances=True),
+        zorder=15,
+        errorbars='band',
+    )
+    assert line._line.get_zorder() == 15
+    assert line._error.get_zorder() == 14  # band is below the line

--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -34,18 +34,34 @@ def test_line_creation_bin_edges():
 def test_line_with_errorbars(mode):
     da = data_array(ndim=1, variances=True)
     line = Line(canvas=Canvas(), data=da, errorbars=mode)
-    assert np.allclose(line._error.x, da.coords['xx'].values)
-    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
-    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
+
+    xline = line._error.get_xdata()
+    xref = da.coords['xx'].values
+    assert np.allclose([xline.min(), xline.max()], [xref.min(), xref.max()])
+    assert np.allclose(
+        line._error.get_ydata().min(), (da.data - sc.stddevs(da.data)).values.min()
+    )
+    assert np.allclose(
+        line._error.get_ydata().max(), (da.data + sc.stddevs(da.data)).values.max()
+    )
 
 
 @pytest.mark.parametrize("mode", ['band', 'bar', True])
 def test_line_with_bin_edges_and_errorbars(mode):
     da = data_array(ndim=1, binedges=True, variances=True)
     line = Line(canvas=Canvas(), data=da, errorbars=mode)
-    assert np.allclose(line._error.x, sc.midpoints(da.coords['xx']).values)
-    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
-    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
+
+    xline = line._error.get_xdata()
+    xref = da.coords['xx'].values
+    if mode != "band":
+        xref = 0.5 * (xref[1:] + xref[:-1])  # Use bin centers for bars
+    assert np.allclose([xline.min(), xline.max()], [xref.min(), xref.max()])
+    assert np.allclose(
+        line._error.get_ydata().min(), (da.data - sc.stddevs(da.data)).values.min()
+    )
+    assert np.allclose(
+        line._error.get_ydata().max(), (da.data + sc.stddevs(da.data)).values.max()
+    )
 
 
 def test_line_hide_errorbars():
@@ -89,15 +105,30 @@ def test_line_update():
 def test_line_update_with_errorbars(mode):
     da = data_array(ndim=1, variances=True)
     line = Line(canvas=Canvas(), data=da, errorbars=mode)
-    assert np.allclose(line._error.x, da.coords['xx'].values)
-    assert np.allclose(line._error.ylower, (da.data - sc.stddevs(da.data)).values)
-    assert np.allclose(line._error.yupper, (da.data + sc.stddevs(da.data)).values)
+
+    xline = line._error.get_xdata()
+    xref = da.coords['xx'].values
+    assert np.allclose([xline.min(), xline.max()], [xref.min(), xref.max()])
+    assert np.allclose(
+        line._error.get_ydata().min(), (da.data - sc.stddevs(da.data)).values.min()
+    )
+    assert np.allclose(
+        line._error.get_ydata().max(), (da.data + sc.stddevs(da.data)).values.max()
+    )
     new_values = da * 2.5
     new_values.variances = da.variances
     line.update(new_values)
-    assert np.allclose(line._error.x, da.coords['xx'].values)
-    assert np.allclose(line._error.ylower, (da.data * 2.5 - sc.stddevs(da.data)).values)
-    assert np.allclose(line._error.yupper, (da.data * 2.5 + sc.stddevs(da.data)).values)
+    xline = line._error.get_xdata()
+    xref = da.coords['xx'].values
+    assert np.allclose([xline.min(), xline.max()], [xref.min(), xref.max()])
+    assert np.allclose(
+        line._error.get_ydata().min(),
+        (da.data * 2.5 - sc.stddevs(da.data)).values.min(),
+    )
+    assert np.allclose(
+        line._error.get_ydata().max(),
+        (da.data * 2.5 + sc.stddevs(da.data)).values.max(),
+    )
 
 
 @pytest.mark.parametrize("mode", ['band', 'bar', True])

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -413,17 +413,26 @@ def test_plot_1d_extra_datetime_coord_binedges():
     pp.plot(da)
 
 
-def test_plot_1d_data_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_plot_1d_data_with_errorbars(mode):
+    da = data_array(ndim=1, variances=True)
+    p = da.plot(errorbars=mode)
+    assert p.canvas.ymin < -1.0
+    assert p.canvas.ymax > 1.0
+
+
+def test_plot_1d_data_with_errorbars_auto():
     da = data_array(ndim=1, variances=True)
     p = da.plot()
     assert p.canvas.ymin < -1.0
     assert p.canvas.ymax > 1.0
 
 
-def test_plot_1d_data_with_variances_and_nan_values():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_plot_1d_data_with_variances_and_nan_values(mode):
     da = data_array(ndim=1, variances=True)
     da.values[-10:] = np.nan
-    p = da.plot()
+    p = da.plot(errorbars=mode)
     assert p.canvas.ymin < -1.0
     assert p.canvas.ymax > 1.0
 
@@ -570,10 +579,11 @@ def test_plot_1d_all_values_masked():
     _ = da.plot()
 
 
-def test_plot_1d_all_values_masked_with_errorbars():
+@pytest.mark.parametrize("mode", ['band', 'bar', True])
+def test_plot_1d_all_values_masked_with_errorbars(mode):
     da = data_array(ndim=1, variances=True)
     da.masks['m'] = sc.scalar(True)
-    _ = da.plot()
+    _ = da.plot(errorbars=mode)
 
 
 def test_can_plot_dict_with_non_string_keys():


### PR DESCRIPTION
We expand the scope of the `errorbars` argument from being just `True/False` to also accepting a string to control the mode for representing errorbars on 1d plots. This can now be a `'band'` which plots as:
<img width="600" height="400" alt="Figure 1 (80)" src="https://github.com/user-attachments/assets/8efc6225-eb46-4157-bdda-230193879d3e" />

Example:
```Py
import plopp as pp

da = pp.data.data1d(variances=True)
da.plot(errorbars='band')
```

Fixes #580 