### PR TITLE
Allow plotting numpy arrays with uint dtypes

### DIFF
--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -57,6 +57,9 @@ def _maybe_to_variable(obj: Plottable | list) -> Plottable:
     if isinstance(out, np.ndarray):
         dims = [f"axis-{i}" for i in range(len(out.shape))]
         if np.issubdtype(out.dtype, np.unsignedinteger):
+            # This conversion is not completely without loss in the case of very large
+            # unsigned integers, but it is probably fine in most cases, and better than
+            # not plotting the data at all.
             out = out.astype('int64')
         out = sc.Variable(dims=dims, values=out)
     return out

--- a/src/plopp/plotting/common.py
+++ b/src/plopp/plotting/common.py
@@ -56,6 +56,8 @@ def _maybe_to_variable(obj: Plottable | list) -> Plottable:
         out = np.array(out)
     if isinstance(out, np.ndarray):
         dims = [f"axis-{i}" for i in range(len(out.shape))]
+        if np.issubdtype(out.dtype, np.unsignedinteger):
+            out = out.astype('int64')
         out = sc.Variable(dims=dims, values=out)
     return out
 

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -34,6 +34,11 @@ def test_plot_variable():
     pp.plot(sc.arange('x', 50.0))
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
+def test_plot_ndarray_uint(dtype):
+    pp.plot(np.arange(50, dtype=dtype))
+
+
 def test_plot_data_array():
     pp.plot(data_array(ndim=1))
 

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -22,6 +22,11 @@ def test_plot_ndarray_int():
     pp.plot(np.arange(50).reshape(5, 10))
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
+def test_plot_ndarray_uint(dtype):
+    pp.plot(np.arange(50, dtype=dtype).reshape(5, 10))
+
+
 def test_plot_variable():
     pp.plot(variable(ndim=2))
 


### PR DESCRIPTION
The following would fail
```Py
import plopp as pp
import numpy as np

a = (np.random.random(20) * 1000).astype('uint32')

pp.plot(a)
```

We now internally convert numpy uint dtypes to int64 before storing into a Scipp variable, to allow plotting them.