### PR TITLE
Cycle only over filled markers for default artist style

### DIFF
--- a/src/plopp/backends/matplotlib/line.py
+++ b/src/plopp/backends/matplotlib/line.py
@@ -9,12 +9,11 @@ import numpy as np
 import scipp as sc
 from matplotlib.axes import Axes
 from matplotlib.dates import date2num
-from matplotlib.lines import Line2D
 
 from ...graphics.bbox import BoundingBox
 from ..common import check_ndim, make_line_bbox, make_line_data
 from .canvas import Canvas
-from .utils import parse_dicts_in_kwargs
+from .utils import default_marker, parse_dicts_in_kwargs
 
 
 def _to_float(x):
@@ -255,11 +254,10 @@ class Line:
             'color': f'C{artist_number}',
             'zorder': 2,
         }
-        markers = list(Line2D.markers.keys())
         default_plot_style = {
             'linestyle': 'none',
             'linewidth': 1.5,
-            'marker': markers[(artist_number + 2) % len(markers)],
+            'marker': default_marker(artist_number),
             'color': f'C{artist_number}',
             'zorder': 2,
         }

--- a/src/plopp/backends/matplotlib/scatter.py
+++ b/src/plopp/backends/matplotlib/scatter.py
@@ -6,14 +6,13 @@ from typing import Literal
 
 import numpy as np
 import scipp as sc
-from matplotlib.lines import Line2D
 
 from ...core.utils import merge_masks
 from ...graphics.bbox import BoundingBox, axis_bounds
 from ...graphics.colormapper import ColorMapper
 from ..common import check_ndim
 from .canvas import Canvas
-from .utils import parse_dicts_in_kwargs
+from .utils import default_marker, parse_dicts_in_kwargs
 
 
 class Scatter:
@@ -79,9 +78,8 @@ class Scatter:
         self._unit = self._data.unit
         self._id = uuid.uuid4().hex
 
-        markers = list(Line2D.markers.keys())
         default_plot_style = {
-            'marker': markers[(artist_number + 2) % len(markers)],
+            'marker': default_marker(artist_number),
         }
         if not cbar:
             default_plot_style['color'] = f'C{artist_number}'

--- a/src/plopp/backends/matplotlib/utils.py
+++ b/src/plopp/backends/matplotlib/utils.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 
 
 def fig_to_bytes(fig: plt.Figure, form: Literal['png', 'svg'] = 'png') -> bytes:
@@ -70,6 +71,18 @@ def make_figure(*args, **kwargs) -> plt.Figure:
         # making it possible to show the figure from the terminal.
         plt._backend_mod.new_figure_manager_given_figure(1, fig)
     return fig
+
+
+def default_marker(artist_number: int) -> str:
+    """
+    Return a marker from a cycle of markers, based on the artist number.
+
+    Only filled markers are used, as ``Line2D.markers`` also contains integer markers
+    and markers that draw nothing (e.g. ``'none'`` and ``''``).
+    """
+    markers = Line2D.filled_markers
+    # Start the cycle at 'o' instead of the barely visible '.'.
+    return markers[(artist_number + 1) % len(markers)]
 
 
 def make_legend(leg: bool | tuple[float, float] | str) -> dict:

--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pytest
 import scipp as sc
+from matplotlib.markers import MarkerStyle
 
 from plopp.backends.matplotlib.canvas import Canvas
 from plopp.backends.matplotlib.line import Line
@@ -179,6 +180,14 @@ def test_kwarg_marker():
     da = data_array(ndim=1)
     line = Line(canvas=Canvas(), data=da, marker='+')
     assert line._line.get_marker() == '+'
+
+
+def test_default_marker_is_visible_for_large_artist_number():
+    da = data_array(ndim=1)
+    canvas = Canvas()
+    for artist_number in range(50):
+        line = Line(canvas=canvas, data=da, artist_number=artist_number)
+        assert MarkerStyle(line.marker).is_filled()
 
 
 @pytest.mark.parametrize("mode", ['band', 'bar', True])

--- a/tests/backends/matplotlib/mpl_plot_test.py
+++ b/tests/backends/matplotlib/mpl_plot_test.py
@@ -202,3 +202,9 @@ def test_aspect_ratio():
     da = data_array(ndim=2)
     fig = da.plot(aspect='equal')
     assert fig.canvas.ax.get_aspect() == 1.0
+
+
+def test_plot_many_lines():
+    da = data_array(ndim=1)
+    fig = pp.plot({str(i): da for i in range(50)})
+    assert len(fig.artists) == 50


### PR DESCRIPTION
Fixes #590.

Plotting 24 or more lines (e.g. from `sc.collapse`) raised `AttributeError: 'int' object has no attribute 'lower'`. The default marker was cycled over `Line2D.markers`, which is the full marker registry rather than a list of usable plot markers: it contains the integer tick and caret markers, and four entries that draw nothing. Beyond 34 artists the markers would have been invisible rather than raising.

Cycling over `Line2D.filled_markers` instead. The shared helper lives in the matplotlib backend utils, since lines and scatter points used the same expression.

On the `+ 2` offset that was there before: it dates back to the initial import and was never touched since, so there is no recorded intent. What it does is skip `'.'` and `','`, the first two entries of `Line2D.markers`, so that the cycle starts at `'o'`. The new `+ 1` offset into `filled_markers` preserves that, and artists 0-4 get the same markers as before. From artist 5 onwards the unfilled markers (`'1' '2' '3' '4' '+' 'x' '|' '_'`) are now skipped; those are the ones that make matplotlib warn when the mask overlay sets an edgecolor, so masks on such lines could not be highlighted as intended. The cycle is 16 long instead of 41, so markers repeat sooner, but colors already repeat every 10.

## Test plan

- New regression tests fail on `main` and pass here.
- Existing test suite passes.
