### PR TITLE
Fix numpy DeprecationWarning for generic timedelta unit in tests

### DIFF
--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -134,7 +134,7 @@ def test_line_update_with_errorbars(mode):
 @pytest.mark.parametrize("mode", ['band', 'bar', True])
 def test_line_datetime_binedges_with_errorbars(mode):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)

--- a/tests/backends/matplotlib/mpl_line_test.py
+++ b/tests/backends/matplotlib/mpl_line_test.py
@@ -134,7 +134,9 @@ def test_line_update_with_errorbars(mode):
 @pytest.mark.parametrize("mode", ['band', 'bar', True])
 def test_line_datetime_binedges_with_errorbars(mode):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -121,7 +121,7 @@ def test_find_limits_with_strings():
 
 def test_find_limits_datetime():
     time = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     da = sc.DataArray(data=sc.array(dims=['time'], values=time))
     lims = find_limits(da)

--- a/tests/core/limits_test.py
+++ b/tests/core/limits_test.py
@@ -121,7 +121,9 @@ def test_find_limits_with_strings():
 
 def test_find_limits_datetime():
     time = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     da = sc.DataArray(data=sc.array(dims=['time'], values=time))
     lims = find_limits(da)

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -296,7 +296,7 @@ def test_plot_1d_includes_masked_data_in_horizontal_range():
 
 def test_plot_1d_datetime_coord():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -309,7 +309,7 @@ def test_plot_1d_datetime_coord():
 
 def test_plot_1d_datetime_coord_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -322,7 +322,7 @@ def test_plot_1d_datetime_coord_binedges():
 
 def test_plot_1d_datetime_coord_with_mask():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -336,7 +336,7 @@ def test_plot_1d_datetime_coord_with_mask():
 
 def test_plot_1d_datetime_coord_with_mask_and_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -350,7 +350,7 @@ def test_plot_1d_datetime_coord_with_mask_and_binedges():
 
 def test_plot_1d_datetime_coord_log():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -363,7 +363,7 @@ def test_plot_1d_datetime_coord_log():
 
 def test_plot_1d_datetime_coord_log_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -376,7 +376,7 @@ def test_plot_1d_datetime_coord_log_binedges():
 
 def test_plot_1d_datetime_coord_log_with_mask():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -390,7 +390,7 @@ def test_plot_1d_datetime_coord_log_with_mask():
 
 def test_plot_1d_datetime_data():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     da = sc.DataArray(

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -296,7 +296,9 @@ def test_plot_1d_includes_masked_data_in_horizontal_range():
 
 def test_plot_1d_datetime_coord():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -309,7 +311,9 @@ def test_plot_1d_datetime_coord():
 
 def test_plot_1d_datetime_coord_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -322,7 +326,9 @@ def test_plot_1d_datetime_coord_binedges():
 
 def test_plot_1d_datetime_coord_with_mask():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -336,7 +342,9 @@ def test_plot_1d_datetime_coord_with_mask():
 
 def test_plot_1d_datetime_coord_with_mask_and_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -350,7 +358,9 @@ def test_plot_1d_datetime_coord_with_mask_and_binedges():
 
 def test_plot_1d_datetime_coord_log():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -363,7 +373,9 @@ def test_plot_1d_datetime_coord_log():
 
 def test_plot_1d_datetime_coord_log_binedges():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'] - 1)
@@ -376,7 +388,9 @@ def test_plot_1d_datetime_coord_log_binedges():
 
 def test_plot_1d_datetime_coord_log_with_mask():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     v = np.random.rand(time.sizes['time'])
@@ -390,7 +404,9 @@ def test_plot_1d_datetime_coord_log_with_mask():
 
 def test_plot_1d_datetime_data():
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     da = sc.DataArray(

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -234,7 +234,9 @@ def test_plot_2d_includes_masked_data_in_vertical_range(linspace):
 @pytest.mark.parametrize('linspace', [True, False])
 def test_plot_2d_datetime_coord(linspace):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     if not linspace:
         t[-1] += np.timedelta64(1, 's')
@@ -251,7 +253,9 @@ def test_plot_2d_datetime_coord(linspace):
 @pytest.mark.parametrize('linspace', [True, False])
 def test_plot_2d_datetime_coord_binedges(linspace):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     if not linspace:
         t[-1] += np.timedelta64(1, 's')
@@ -317,7 +321,9 @@ def test_plot_1d_data_over_2d_data():
 def test_plot_1d_data_over_2d_data_datetime():
     # 2d data
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
+        np.datetime64('2017-03-16T20:58:17'),
+        np.datetime64('2017-03-16T21:15:17'),
+        np.timedelta64(20, 's'),
     )
     time = sc.array(dims=['time'], values=t)
     z = sc.arange('z', 50.0, unit='m')

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -234,7 +234,7 @@ def test_plot_2d_includes_masked_data_in_vertical_range(linspace):
 @pytest.mark.parametrize('linspace', [True, False])
 def test_plot_2d_datetime_coord(linspace):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     if not linspace:
         t[-1] += np.timedelta64(1, 's')
@@ -251,7 +251,7 @@ def test_plot_2d_datetime_coord(linspace):
 @pytest.mark.parametrize('linspace', [True, False])
 def test_plot_2d_datetime_coord_binedges(linspace):
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     if not linspace:
         t[-1] += np.timedelta64(1, 's')
@@ -317,7 +317,7 @@ def test_plot_1d_data_over_2d_data():
 def test_plot_1d_data_over_2d_data_datetime():
     # 2d data
     t = np.arange(
-        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
+        np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), np.timedelta64(20, 's')
     )
     time = sc.array(dims=['time'], values=t)
     z = sc.arange('z', 50.0, unit='m')


### PR DESCRIPTION
Fixes pytest failures we encountered with Nix:

```
=================================== FAILURES ===================================
_________ test_line_datetime_binedges_with_errorbars[mpl-static-band] __________

mode = 'band'

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
__________ test_line_datetime_binedges_with_errorbars[mpl-static-bar] __________

mode = 'bar'

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
_________ test_line_datetime_binedges_with_errorbars[mpl-static-True] __________

mode = True

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
_______ test_line_datetime_binedges_with_errorbars[mpl-interactive-band] _______

mode = 'band'

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
_______ test_line_datetime_binedges_with_errorbars[mpl-interactive-bar] ________

mode = 'bar'

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
_______ test_line_datetime_binedges_with_errorbars[mpl-interactive-True] _______

mode = True

    @pytest.mark.parametrize("mode", ['band', 'bar', True])
    def test_line_datetime_binedges_with_errorbars(mode):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/backends/matplotlib/mpl_line_test.py:136: DeprecationWarning
__________________________ test_find_limits_datetime ___________________________

    def test_find_limits_datetime():
>       time = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/core/limits_test.py:123: DeprecationWarning
___________________ test_plot_1d_datetime_coord[mpl-static] ____________________

    def test_plot_1d_datetime_coord():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:298: DeprecationWarning
_________________ test_plot_1d_datetime_coord[mpl-interactive] _________________

    def test_plot_1d_datetime_coord():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:298: DeprecationWarning
_______________ test_plot_1d_datetime_coord_binedges[mpl-static] _______________

    def test_plot_1d_datetime_coord_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:311: DeprecationWarning
____________ test_plot_1d_datetime_coord_binedges[mpl-interactive] _____________

    def test_plot_1d_datetime_coord_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:311: DeprecationWarning
______________ test_plot_1d_datetime_coord_with_mask[mpl-static] _______________

    def test_plot_1d_datetime_coord_with_mask():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:324: DeprecationWarning
____________ test_plot_1d_datetime_coord_with_mask[mpl-interactive] ____________

    def test_plot_1d_datetime_coord_with_mask():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:324: DeprecationWarning
________ test_plot_1d_datetime_coord_with_mask_and_binedges[mpl-static] ________

    def test_plot_1d_datetime_coord_with_mask_and_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:338: DeprecationWarning
_____ test_plot_1d_datetime_coord_with_mask_and_binedges[mpl-interactive] ______

    def test_plot_1d_datetime_coord_with_mask_and_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:338: DeprecationWarning
_________________ test_plot_1d_datetime_coord_log[mpl-static] __________________

    def test_plot_1d_datetime_coord_log():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:352: DeprecationWarning
_______________ test_plot_1d_datetime_coord_log[mpl-interactive] _______________

    def test_plot_1d_datetime_coord_log():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:352: DeprecationWarning
_____________ test_plot_1d_datetime_coord_log_binedges[mpl-static] _____________

    def test_plot_1d_datetime_coord_log_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:365: DeprecationWarning
__________ test_plot_1d_datetime_coord_log_binedges[mpl-interactive] ___________

    def test_plot_1d_datetime_coord_log_binedges():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:365: DeprecationWarning
____________ test_plot_1d_datetime_coord_log_with_mask[mpl-static] _____________

    def test_plot_1d_datetime_coord_log_with_mask():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:378: DeprecationWarning
__________ test_plot_1d_datetime_coord_log_with_mask[mpl-interactive] __________

    def test_plot_1d_datetime_coord_log_with_mask():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:378: DeprecationWarning
____________________ test_plot_1d_datetime_data[mpl-static] ____________________

    def test_plot_1d_datetime_data():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:392: DeprecationWarning
_________________ test_plot_1d_datetime_data[mpl-interactive] __________________

    def test_plot_1d_datetime_data():
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_1d_test.py:392: DeprecationWarning
_________________ test_plot_2d_datetime_coord[mpl-static-True] _________________

linspace = True

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:236: DeprecationWarning
________________ test_plot_2d_datetime_coord[mpl-static-False] _________________

linspace = False

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:236: DeprecationWarning
______________ test_plot_2d_datetime_coord[mpl-interactive-True] _______________

linspace = True

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:236: DeprecationWarning
______________ test_plot_2d_datetime_coord[mpl-interactive-False] ______________

linspace = False

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:236: DeprecationWarning
____________ test_plot_2d_datetime_coord_binedges[mpl-static-True] _____________

linspace = True

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord_binedges(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:253: DeprecationWarning
____________ test_plot_2d_datetime_coord_binedges[mpl-static-False] ____________

linspace = False

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord_binedges(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:253: DeprecationWarning
__________ test_plot_2d_datetime_coord_binedges[mpl-interactive-True] __________

linspace = True

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord_binedges(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:253: DeprecationWarning
_________ test_plot_2d_datetime_coord_binedges[mpl-interactive-False] __________

linspace = False

    @pytest.mark.parametrize('linspace', [True, False])
    def test_plot_2d_datetime_coord_binedges(linspace):
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:253: DeprecationWarning
_____________ test_plot_1d_data_over_2d_data_datetime[mpl-static] ______________

    def test_plot_1d_data_over_2d_data_datetime():
        # 2d data
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:319: DeprecationWarning
___________ test_plot_1d_data_over_2d_data_datetime[mpl-interactive] ___________

    def test_plot_1d_data_over_2d_data_datetime():
        # 2d data
>       t = np.arange(
            np.datetime64('2017-03-16T20:58:17'), np.datetime64('2017-03-16T21:15:17'), 20
        )
E       DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.

tests/plotting/plot_2d_test.py:319: DeprecationWarning
=========================== short test summary info ============================
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-static-band] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-static-bar] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-static-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-interactive-band] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-interactive-bar] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/backends/matplotlib/mpl_line_test.py::test_line_datetime_binedges_with_errorbars[mpl-interactive-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/core/limits_test.py::test_find_limits_datetime - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_binedges[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_binedges[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_with_mask[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_with_mask[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_with_mask_and_binedges[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_with_mask_and_binedges[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log_binedges[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log_binedges[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log_with_mask[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_coord_log_with_mask[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_data[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_1d_test.py::test_plot_1d_datetime_data[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord[mpl-static-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord[mpl-static-False] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord[mpl-interactive-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord[mpl-interactive-False] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord_binedges[mpl-static-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord_binedges[mpl-static-False] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord_binedges[mpl-interactive-True] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_2d_datetime_coord_binedges[mpl-interactive-False] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_1d_data_over_2d_data_datetime[mpl-static] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
FAILED tests/plotting/plot_2d_test.py::test_plot_1d_data_over_2d_data_datetime[mpl-interactive] - DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, a...
================ 33 failed, 1240 passed, 3 deselected in 58.29s ================
```

