### PR TITLE
monkeypatch _mathtext.Parser.parse() with a threading.Lock()

### DIFF
--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -44,4 +44,29 @@ from .backends import BackendManager
 
 backends = BackendManager()
 
+# Workaround for thread-safety issues in matplotlib's mathtext parser.
+# The _mathtext.Parser singleton has mutable state (_state_stack, etc.) that is
+# not protected against concurrent access from multiple threads. When ipympl is
+# used with ipykernel >= 7 (which introduces additional threads for message
+# routing), concurrent calls to the parser can corrupt this state, leading to
+# ParseException errors like 'Expected end of text, found "$"'.
+# See https://github.com/matplotlib/ipympl/issues/610
+try:
+    import functools
+    from threading import Lock
+
+    from matplotlib._mathtext import Parser as _MathTextInternalParser
+
+    _mathtext_parse_lock = Lock()
+    _original_mathtext_parse = _MathTextInternalParser.parse
+
+    @functools.wraps(_original_mathtext_parse)
+    def _thread_safe_mathtext_parse(self, *args, **kwargs):
+        with _mathtext_parse_lock:
+            return _original_mathtext_parse(self, *args, **kwargs)
+
+    _MathTextInternalParser.parse = _thread_safe_mathtext_parse
+except Exception:
+    pass
+
 del importlib

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -66,6 +66,8 @@ try:
             return _original_mathtext_parse(self, *args, **kwargs)
 
     _MathTextInternalParser.parse = _thread_safe_mathtext_parse
+
+    del functools, Lock
 except Exception:
     pass
 

--- a/src/plopp/__init__.py
+++ b/src/plopp/__init__.py
@@ -68,7 +68,7 @@ try:
     _MathTextInternalParser.parse = _thread_safe_mathtext_parse
 
     del functools, Lock
-except Exception:
+except Exception:  # noqa: S110
     pass
 
 del importlib


### PR DESCRIPTION
Copied from https://github.com/matplotlib/ipympl/pull/621

I don't know if this is the right place to put it, with the lazy_loader and everything. We may not want to do that work as soon as we import plopp?

I think we could potentially move it into the `backends/matplotlib/__init__.py` because the other places where matplotlib is used (e.g. making the colorbar for 3d scatter plots) don't make use of `ipympl`.

Either choice would lead to a somewhat possibly surprising behaviour for other plain MPL figures:

- if we keep it in top-level init, after importing plopp, it would fix other custom mpl figures
- in the backends/matplotlib/__init__, it would fix other figures after we have made a 1d or 2d figure with plopp

