### PR TITLE
test: filter deprecation warning with numpy>=2.5 and matplotlib<3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ filterwarnings = [
   'ignore:Parsing dates involving a day of month without a year:DeprecationWarning',
   # Should be removed once we lower pin a matplotlib version that respects the deprecation
   'ignore:.*parameter is deprecated and will be removed in Pillow 13.*:DeprecationWarning',
+  # Matplotlib <= 3.10 uses a generic-unit NaT, which is deprecated in NumPy 2.5.
+  # Remove once the minimum supported Matplotlib version is >= 3.11.
+  "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning:matplotlib[.]dates",
   # Warnings related to pyparsing deprecations: this is fixed in mpl==3.10.8 onwards
   "ignore:'parseString' deprecated:DeprecationWarning",
   "ignore:'resetCache' deprecated:DeprecationWarning",


### PR DESCRIPTION
With `numpy>=2.5` and `matplotlib<3.11` some tests raise the deprecation warning

> The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit
  conversion of bare integers (e.g. `+ 1`). Please use a specific unit instead.
  
